### PR TITLE
Merge develop

### DIFF
--- a/all/modules/geocoding/MapBoxOnlineGeocodingService.i
+++ b/all/modules/geocoding/MapBoxOnlineGeocodingService.i
@@ -28,6 +28,7 @@
 
 %attribute(carto::MapBoxOnlineGeocodingService, bool, Autocomplete, isAutocomplete, setAutocomplete)
 %attributestring(carto::MapBoxOnlineGeocodingService, std::string, Language, getLanguage, setLanguage)
+%attributestring(carto::MapBoxOnlineGeocodingService, std::string, CustomServiceURL, getCustomServiceURL, setCustomServiceURL)
 %std_io_exceptions(carto::MapBoxOnlineGeocodingService::calculateAddresses)
 
 %feature("director") carto::MapBoxOnlineGeocodingService;

--- a/all/modules/geocoding/MapBoxOnlineGeocodingService.i
+++ b/all/modules/geocoding/MapBoxOnlineGeocodingService.i
@@ -1,0 +1,37 @@
+#ifndef _MAPBOXONLINEGEOCODINGSERVICE_I
+#define _MAPBOXONLINEGEOCODINGSERVICE_I
+
+#pragma SWIG nowarn=325
+#pragma SWIG nowarn=401
+
+%module(directors="1") MapBoxOnlineGeocodingService
+
+#if defined(_CARTO_GEOCODING_SUPPORT)
+
+!proxy_imports(carto::MapBoxOnlineGeocodingService, geocoding.GeocodingService, geocoding.GeocodingRequest, geocoding.GeocodingResult, projections.Projection)
+
+%{
+#include "geocoding/MapBoxOnlineGeocodingService.h"
+#include "components/Exceptions.h"
+#include <memory>
+%}
+
+%include <std_shared_ptr.i>
+%include <cartoswig.i>
+
+%import "geocoding/GeocodingService.i"
+%import "geocoding/GeocodingRequest.i"
+%import "geocoding/GeocodingResult.i"
+
+!polymorphic_shared_ptr(carto::MapBoxOnlineGeocodingService, geocoding.MapBoxOnlineGeocodingService)
+
+%attribute(carto::MapBoxOnlineGeocodingService, bool, Autocomplete, isAutocomplete, setAutocomplete)
+%std_io_exceptions(carto::MapBoxOnlineGeocodingService::calculateAddresses)
+
+%feature("director") carto::MapBoxOnlineGeocodingService;
+
+%include "geocoding/MapBoxOnlineGeocodingService.h"
+
+#endif
+
+#endif

--- a/all/modules/geocoding/MapBoxOnlineGeocodingService.i
+++ b/all/modules/geocoding/MapBoxOnlineGeocodingService.i
@@ -17,6 +17,7 @@
 %}
 
 %include <std_shared_ptr.i>
+%include <std_string.i>
 %include <cartoswig.i>
 
 %import "geocoding/GeocodingService.i"
@@ -26,6 +27,7 @@
 !polymorphic_shared_ptr(carto::MapBoxOnlineGeocodingService, geocoding.MapBoxOnlineGeocodingService)
 
 %attribute(carto::MapBoxOnlineGeocodingService, bool, Autocomplete, isAutocomplete, setAutocomplete)
+%attributestring(carto::MapBoxOnlineGeocodingService, std::string, Language, getLanguage, setLanguage)
 %std_io_exceptions(carto::MapBoxOnlineGeocodingService::calculateAddresses)
 
 %feature("director") carto::MapBoxOnlineGeocodingService;

--- a/all/modules/geocoding/MapBoxOnlineReverseGeocodingService.i
+++ b/all/modules/geocoding/MapBoxOnlineReverseGeocodingService.i
@@ -17,6 +17,7 @@
 %}
 
 %include <std_shared_ptr.i>
+%include <std_string.i>
 %include <cartoswig.i>
 
 %import "geocoding/ReverseGeocodingService.i"
@@ -25,6 +26,7 @@
 
 !polymorphic_shared_ptr(carto::MapBoxOnlineReverseGeocodingService, geocoding.MapBoxOnlineReverseGeocodingService)
 
+%attributestring(carto::MapBoxOnlineReverseGeocodingService, std::string, Language, getLanguage, setLanguage)
 %std_io_exceptions(carto::MapBoxOnlineReverseGeocodingService::calculateAddresses)
 
 %feature("director") carto::MapBoxOnlineReverseGeocodingService;

--- a/all/modules/geocoding/MapBoxOnlineReverseGeocodingService.i
+++ b/all/modules/geocoding/MapBoxOnlineReverseGeocodingService.i
@@ -27,6 +27,7 @@
 !polymorphic_shared_ptr(carto::MapBoxOnlineReverseGeocodingService, geocoding.MapBoxOnlineReverseGeocodingService)
 
 %attributestring(carto::MapBoxOnlineReverseGeocodingService, std::string, Language, getLanguage, setLanguage)
+%attributestring(carto::MapBoxOnlineReverseGeocodingService, std::string, CustomServiceURL, getCustomServiceURL, setCustomServiceURL)
 %std_io_exceptions(carto::MapBoxOnlineReverseGeocodingService::calculateAddresses)
 
 %feature("director") carto::MapBoxOnlineReverseGeocodingService;

--- a/all/modules/geocoding/MapBoxOnlineReverseGeocodingService.i
+++ b/all/modules/geocoding/MapBoxOnlineReverseGeocodingService.i
@@ -1,0 +1,36 @@
+#ifndef _MAPBOXONLINEREVERSEGEOCODINGSERVICE_I
+#define _MAPBOXONLINEREVERSEGEOCODINGSERVICE_I
+
+#pragma SWIG nowarn=325
+#pragma SWIG nowarn=401
+
+%module(directors="1") MapBoxOnlineReverseGeocodingService
+
+#if defined(_CARTO_GEOCODING_SUPPORT)
+
+!proxy_imports(carto::MapBoxOnlineReverseGeocodingService, geocoding.ReverseGeocodingService, geocoding.ReverseGeocodingRequest, geocoding.GeocodingResult, projections.Projection)
+
+%{
+#include "geocoding/MapBoxOnlineReverseGeocodingService.h"
+#include "components/Exceptions.h"
+#include <memory>
+%}
+
+%include <std_shared_ptr.i>
+%include <cartoswig.i>
+
+%import "geocoding/ReverseGeocodingService.i"
+%import "geocoding/ReverseGeocodingRequest.i"
+%import "geocoding/GeocodingResult.i"
+
+!polymorphic_shared_ptr(carto::MapBoxOnlineReverseGeocodingService, geocoding.MapBoxOnlineReverseGeocodingService)
+
+%std_io_exceptions(carto::MapBoxOnlineReverseGeocodingService::calculateAddresses)
+
+%feature("director") carto::MapBoxOnlineReverseGeocodingService;
+
+%include "geocoding/MapBoxOnlineReverseGeocodingService.h"
+
+#endif
+
+#endif

--- a/all/modules/geocoding/PeliasOnlineGeocodingService.i
+++ b/all/modules/geocoding/PeliasOnlineGeocodingService.i
@@ -27,6 +27,7 @@
 !polymorphic_shared_ptr(carto::PeliasOnlineGeocodingService, geocoding.PeliasOnlineGeocodingService)
 
 %attribute(carto::PeliasOnlineGeocodingService, bool, Autocomplete, isAutocomplete, setAutocomplete)
+%attributestring(carto::PeliasOnlineGeocodingService, std::string, CustomServiceURL, getCustomServiceURL, setCustomServiceURL)
 %std_io_exceptions(carto::PeliasOnlineGeocodingService::calculateAddresses)
 
 %feature("director") carto::PeliasOnlineGeocodingService;

--- a/all/modules/geocoding/PeliasOnlineGeocodingService.i
+++ b/all/modules/geocoding/PeliasOnlineGeocodingService.i
@@ -17,6 +17,7 @@
 %}
 
 %include <std_shared_ptr.i>
+%include <std_string.i>
 %include <cartoswig.i>
 
 %import "geocoding/GeocodingService.i"

--- a/all/modules/geocoding/PeliasOnlineReverseGeocodingService.i
+++ b/all/modules/geocoding/PeliasOnlineReverseGeocodingService.i
@@ -26,6 +26,7 @@
 
 !polymorphic_shared_ptr(carto::PeliasOnlineReverseGeocodingService, geocoding.PeliasOnlineReverseGeocodingService)
 
+%attributestring(carto::PeliasOnlineReverseGeocodingService, std::string, CustomServiceURL, getCustomServiceURL, setCustomServiceURL)
 %std_io_exceptions(carto::PeliasOnlineReverseGeocodingService::calculateAddresses)
 
 %feature("director") carto::PeliasOnlineReverseGeocodingService;

--- a/all/modules/geocoding/PeliasOnlineReverseGeocodingService.i
+++ b/all/modules/geocoding/PeliasOnlineReverseGeocodingService.i
@@ -17,6 +17,7 @@
 %}
 
 %include <std_shared_ptr.i>
+%include <std_string.i>
 %include <cartoswig.i>
 
 %import "geocoding/ReverseGeocodingService.i"

--- a/all/modules/routing/ValhallaOnlineRoutingService.i
+++ b/all/modules/routing/ValhallaOnlineRoutingService.i
@@ -22,6 +22,7 @@
 !polymorphic_shared_ptr(carto::ValhallaOnlineRoutingService, routing.ValhallaOnlineRoutingService)
 
 %attributestring(carto::ValhallaOnlineRoutingService, std::string, Profile, getProfile, setProfile)
+%attributestring(carto::ValhallaOnlineRoutingService, std::string, CustomServiceURL, getCustomServiceURL, setCustomServiceURL)
 %std_io_exceptions(carto::ValhallaOnlineRoutingService::calculateRoute)
 
 %feature("director") carto::ValhallaOnlineRoutingService;

--- a/all/native/datasources/CartoOnlineTileDataSource.cpp
+++ b/all/native/datasources/CartoOnlineTileDataSource.cpp
@@ -26,7 +26,7 @@ namespace carto {
         _randomGenerator(),
         _mutex()
     {
-        _maxZoom = (isMapZenSource() ? MAPZEN_MAX_ZOOM : CARTO_MAX_ZOOM);
+        _maxZoom = DEFAULT_MAX_ZOOM;
     }
     
     CartoOnlineTileDataSource::~CartoOnlineTileDataSource() {
@@ -87,10 +87,6 @@ namespace carto {
         }
         
         return tileData;
-    }
-
-    bool CartoOnlineTileDataSource::isMapZenSource() const {
-        return _source.substr(0, 7) == "mapzen.";
     }
 
     std::string CartoOnlineTileDataSource::buildTileURL(const std::string& baseURL, const MapTile& tile) const {
@@ -221,7 +217,7 @@ namespace carto {
         }
         int maxAge = NetworkUtils::GetMaxAgeHTTPHeader(responseHeaders);
         auto tileData = std::make_shared<TileData>(responseData);
-        if (maxAge >= 0 && !isMapZenSource()) { // set max age header but only for non-mapzen sources as mapzen always sets max-age to 0
+        if (maxAge > 0) {
             Log::Infof("CartoOnlineTileDataSource::loadOnlineTile: Setting tile %d/%d/%d maxage=%d", mapTile.getZoom(), mapTile.getX(), mapTile.getY(), maxAge);
             tileData->setMaxAge(maxAge * 1000);
         }

--- a/all/native/datasources/CartoOnlineTileDataSource.h
+++ b/all/native/datasources/CartoOnlineTileDataSource.h
@@ -48,16 +48,13 @@ namespace carto {
             std::shared_ptr<BinaryData> tileData;
         };
 
-        bool isMapZenSource() const;
-
         std::string buildTileURL(const std::string& baseURL, const MapTile& tile) const;
 
         bool loadConfiguration();
 
         std::shared_ptr<TileData> loadOnlineTile(const std::string& url, const MapTile& mapTile);
 
-        static const int CARTO_MAX_ZOOM = 14;
-        static const int MAPZEN_MAX_ZOOM = 17;
+        static const int DEFAULT_MAX_ZOOM = 14;
         static const int MAX_CACHED_TILES = 8;
         static const std::string TILE_SERVICE_URL;
 

--- a/all/native/geocoding/MapBoxGeocodingProxy.cpp
+++ b/all/native/geocoding/MapBoxGeocodingProxy.cpp
@@ -1,0 +1,101 @@
+#ifdef _CARTO_GEOCODING_SUPPORT
+
+#include "MapBoxGeocodingProxy.h"
+#include "core/Address.h"
+#include "core/Variant.h"
+#include "components/Exceptions.h"
+#include "geometry/Feature.h"
+#include "geometry/FeatureCollection.h"
+#include "geometry/Geometry.h"
+#include "geometry/GeoJSONGeometryReader.h"
+#include "projections/Projection.h"
+#include "utils/Log.h"
+#include "utils/GeneralUtils.h"
+
+#include <picojson/picojson.h>
+
+namespace carto {
+
+    std::vector<std::shared_ptr<GeocodingResult> > MapBoxGeocodingProxy::ReadResponse(const std::string& responseString, const std::shared_ptr<Projection>& proj) {
+        picojson::value response;
+        std::string err = picojson::parse(response, responseString);
+        if (!err.empty()) {
+            throw GenericException("Failed to parse response", err);
+        }
+
+        if (!response.get("features").is<picojson::array>()) {
+            throw GenericException("No features in the response");
+        }
+
+        GeoJSONGeometryReader reader;
+        reader.setTargetProjection(proj);
+
+        std::vector<std::shared_ptr<GeocodingResult> > results;
+        for (const picojson::value& featureInfo : response.get("features").get<picojson::array>()) {
+            std::string country, region, county, locality, neighbourhood, street, postcode, houseNumber, name;
+
+            auto extractField = [&](const picojson::value& info) {
+                if (info.contains("id")) {
+                    std::string id = info.get("id").get<std::string>();
+                    std::string type = id.substr(0, id.find("."));
+                    std::string text = info.contains("text") ? info.get("text").get<std::string>() : std::string();
+                    if (type == "country") {
+                        country = text;
+                    } else if (type == "region") {
+                        region = text;
+                    } else if (type == "district") {
+                        country = text;
+                    } else if (type == "place" || type == "locality") {
+                        locality = text;
+                    } else if (type == "neighbourhood") {
+                        neighbourhood = text;
+                    } else if (type == "address") {
+                        // NOTE: this is a ugly hack but works in most of the cases
+                        std::string::size_type pos = text.find(" ");
+                        if (pos != std::string::npos) {
+                            houseNumber = text.substr(0, pos);
+                            street = text.substr(pos + 1);
+                        }
+                    } else if (type == "postcode") {
+                        postcode = text;
+                    } else {
+                        name = text;
+                    }
+                }
+            };
+
+            extractField(featureInfo);
+            if (response.contains("context")) {
+                for (const picojson::value& contextInfo : response.get("context").get<picojson::array>()) {
+                    extractField(contextInfo);
+                }
+            }
+
+            std::vector<std::string> categories;
+            if (featureInfo.contains("properties")) {
+                const picojson::value& properties = featureInfo.get("properties");
+                if (properties.contains("categories")) {
+                    categories = GeneralUtils::Split(properties.get("categories").get<std::string>(), ',');
+                }
+            }
+
+            Address address(country, region, county, locality, neighbourhood, street, postcode, houseNumber, name, categories);
+            float rank = static_cast<float>(featureInfo.contains("relevance") ? featureInfo.get("relevance").get<double>() : 0.5);
+
+            std::shared_ptr<Geometry> geometry = reader.readGeometry(featureInfo.get("geometry").serialize());
+
+            auto feature = std::make_shared<Feature>(geometry, Variant());
+            auto featureCollection = std::make_shared<FeatureCollection>(std::vector<std::shared_ptr<Feature> > { feature });
+
+            auto result = std::make_shared<GeocodingResult>(proj, address, rank, featureCollection);
+            results.push_back(result);
+        }
+        return results;
+    }
+
+    MapBoxGeocodingProxy::MapBoxGeocodingProxy() {
+    }
+    
+}
+
+#endif

--- a/all/native/geocoding/MapBoxGeocodingProxy.cpp
+++ b/all/native/geocoding/MapBoxGeocodingProxy.cpp
@@ -36,9 +36,9 @@ namespace carto {
 
             auto extractField = [&](const picojson::value& info) {
                 if (info.contains("id")) {
-                    std::string id = info.get("id").get<std::string>();
+                    std::string id = info.get("id").to_str();
                     std::string type = id.substr(0, id.find("."));
-                    std::string text = info.contains("text") ? info.get("text").get<std::string>() : std::string();
+                    std::string text = info.contains("text") ? info.get("text").to_str() : std::string();
                     if (type == "country") {
                         country = text;
                     } else if (type == "region") {
@@ -67,14 +67,14 @@ namespace carto {
             }
             
             if (featureInfo.contains("address")) {
-                houseNumber = featureInfo.get("address").get<std::string>();
+                houseNumber = featureInfo.get("address").to_str();
             }
 
             std::vector<std::string> categories;
             if (featureInfo.contains("properties")) {
                 const picojson::value& properties = featureInfo.get("properties");
                 if (properties.contains("categories")) {
-                    categories = GeneralUtils::Split(properties.get("categories").get<std::string>(), ',');
+                    categories = GeneralUtils::Split(properties.get("categories").to_str(), ',');
                 }
             }
 

--- a/all/native/geocoding/MapBoxGeocodingProxy.cpp
+++ b/all/native/geocoding/MapBoxGeocodingProxy.cpp
@@ -50,12 +50,7 @@ namespace carto {
                     } else if (type == "neighbourhood") {
                         neighbourhood = text;
                     } else if (type == "address") {
-                        // NOTE: this is a ugly hack but works in most of the cases
-                        std::string::size_type pos = text.find(" ");
-                        if (pos != std::string::npos) {
-                            houseNumber = text.substr(0, pos);
-                            street = text.substr(pos + 1);
-                        }
+                        street = text;
                     } else if (type == "postcode") {
                         postcode = text;
                     } else {
@@ -65,10 +60,14 @@ namespace carto {
             };
 
             extractField(featureInfo);
-            if (response.contains("context")) {
-                for (const picojson::value& contextInfo : response.get("context").get<picojson::array>()) {
+            if (featureInfo.contains("context")) {
+                for (const picojson::value& contextInfo : featureInfo.get("context").get<picojson::array>()) {
                     extractField(contextInfo);
                 }
+            }
+            
+            if (featureInfo.contains("address")) {
+                houseNumber = featureInfo.get("address").get<std::string>();
             }
 
             std::vector<std::string> categories;

--- a/all/native/geocoding/MapBoxGeocodingProxy.h
+++ b/all/native/geocoding/MapBoxGeocodingProxy.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2016 CartoDB. All rights reserved.
+ * Copying and using this code is allowed only according
+ * to license terms, as given in https://cartodb.com/terms/
+ */
+
+#ifndef _CARTO_MAPBOXGEOCODINGPROXY_H_
+#define _CARTO_MAPBOXGEOCODINGPROXY_H_
+
+#ifdef _CARTO_GEOCODING_SUPPORT
+
+#include "geocoding/GeocodingResult.h"
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace carto {
+    class Projection;
+    
+    class MapBoxGeocodingProxy {
+    public:
+        static std::vector<std::shared_ptr<GeocodingResult> > ReadResponse(const std::string& responseString, const std::shared_ptr<Projection>& proj);
+
+    private:
+        MapBoxGeocodingProxy();
+    };
+    
+}
+
+#endif
+
+#endif

--- a/all/native/geocoding/MapBoxOnlineGeocodingService.cpp
+++ b/all/native/geocoding/MapBoxOnlineGeocodingService.cpp
@@ -55,7 +55,7 @@ namespace carto {
 
         if (request->getLocationRadius() > 0) {
             MapPos focusPoint = request->getProjection()->toWgs84(request->getLocation());
-            params["proximity"] = boost::lexical_cast<std::string>(focusPoint.getY()) + "," + boost::lexical_cast<std::string>(focusPoint.getX());
+            params["proximity"] = boost::lexical_cast<std::string>(focusPoint.getX()) + "," + boost::lexical_cast<std::string>(focusPoint.getY());
             // TODO: bbox
         }
 

--- a/all/native/geocoding/MapBoxOnlineGeocodingService.cpp
+++ b/all/native/geocoding/MapBoxOnlineGeocodingService.cpp
@@ -116,7 +116,7 @@ namespace carto {
         return MapBoxGeocodingProxy::ReadResponse(responseString, request->getProjection());
     }
 
-    const std::string MapBoxOnlineGeocodingService::MAPBOX_SERVICE_URL = "https://api.mapbox.com/geocoding/v5/mapbox.places/{query}.json&access_token={access_token}";
+    const std::string MapBoxOnlineGeocodingService::MAPBOX_SERVICE_URL = "https://api.mapbox.com/geocoding/v5/mapbox.places/{query}.json?access_token={access_token}";
 }
 
 #endif

--- a/all/native/geocoding/MapBoxOnlineGeocodingService.cpp
+++ b/all/native/geocoding/MapBoxOnlineGeocodingService.cpp
@@ -1,0 +1,83 @@
+#if defined(_CARTO_GEOCODING_SUPPORT)
+
+#include "MapBoxOnlineGeocodingService.h"
+#include "core/BinaryData.h"
+#include "components/Exceptions.h"
+#include "geocoding/MapBoxGeocodingProxy.h"
+#include "projections/Projection.h"
+#include "utils/NetworkUtils.h"
+#include "utils/Log.h"
+
+#include <map>
+
+#include <boost/lexical_cast.hpp>
+
+namespace carto {
+
+    MapBoxOnlineGeocodingService::MapBoxOnlineGeocodingService(const std::string& apiKey) :
+        _apiKey(apiKey),
+        _autocomplete(false),
+        _mutex()
+    {
+    }
+
+    MapBoxOnlineGeocodingService::~MapBoxOnlineGeocodingService() {
+    }
+
+    bool MapBoxOnlineGeocodingService::isAutocomplete() const {
+        std::lock_guard<std::mutex> lock(_mutex);
+        return _autocomplete;
+    }
+
+    void MapBoxOnlineGeocodingService::setAutocomplete(bool autocomplete) {
+        std::lock_guard<std::mutex> lock(_mutex);
+        _autocomplete = autocomplete;
+    }
+
+    std::vector<std::shared_ptr<GeocodingResult> > MapBoxOnlineGeocodingService::calculateAddresses(const std::shared_ptr<GeocodingRequest>& request) const {
+        if (!request) {
+            throw NullArgumentException("Null request");
+        }
+
+        if (request->getQuery().empty()) {
+            return std::vector<std::shared_ptr<GeocodingResult> >();
+        }
+
+        std::string baseURL = MAPBOX_SERVICE_URL + NetworkUtils::URLEncode(request->getQuery()) + ".json";
+
+        std::map<std::string, std::string> params;
+        {
+            std::lock_guard<std::mutex> lock(_mutex);
+            params["access_token"] = _apiKey;
+            params["autocomplete"] = _autocomplete ? "true" : "false";
+            // TODO: language
+        }
+
+        if (request->getLocationRadius() > 0) {
+            MapPos focusPoint = request->getProjection()->toWgs84(request->getLocation());
+            params["proximity"] = boost::lexical_cast<std::string>(focusPoint.getY()) + "," + boost::lexical_cast<std::string>(focusPoint.getX());
+            // TODO: bbox
+        }
+
+        std::string url = NetworkUtils::BuildURLFromParameters(baseURL, params);
+        Log::Debugf("MapBoxOnlineGeocodingService::calculateAddresses: Loading %s", url.c_str());
+
+        std::shared_ptr<BinaryData> responseData;
+        if (!NetworkUtils::GetHTTP(url, responseData, Log::IsShowDebug())) {
+            throw NetworkException("Failed to fetch response");
+        }
+
+        std::string responseString;
+        if (responseData) {
+            responseString = std::string(reinterpret_cast<const char*>(responseData->data()), responseData->size());
+        } else {
+            throw GenericException("Empty response");
+        }
+
+        return MapBoxGeocodingProxy::ReadResponse(responseString, request->getProjection());
+    }
+
+    const std::string MapBoxOnlineGeocodingService::MAPBOX_SERVICE_URL = "https://api.mapbox.com/geocoding/v5/mapbox.places/";
+}
+
+#endif

--- a/all/native/geocoding/MapBoxOnlineGeocodingService.h
+++ b/all/native/geocoding/MapBoxOnlineGeocodingService.h
@@ -51,6 +51,18 @@ namespace carto {
          */
         void setLanguage(const std::string& lang);
 
+        /**
+         * Returns the custom backend service URL.
+         * @return The custom backend service URL. If this is not defined, an empty string is returned.
+         */
+        std::string getCustomServiceURL() const;
+        /**
+         * Sets the custom backend service URL. 
+         * The custom URL should contain tags "{query}" and "{access_token}" that will be substituted by the SDK.
+         * @param serviceURL The custom backend service URL to use. If this is empty, then the default service is used.
+         */
+        void setCustomServiceURL(const std::string& serviceURL);
+
         virtual std::vector<std::shared_ptr<GeocodingResult> > calculateAddresses(const std::shared_ptr<GeocodingRequest>& request) const;
 
     protected:
@@ -58,9 +70,11 @@ namespace carto {
 
         const std::string _accessToken;
 
+        bool _autocomplete;
+
         std::string _language;
 
-        bool _autocomplete;
+        std::string _serviceURL;
 
         mutable std::mutex _mutex;
     };

--- a/all/native/geocoding/MapBoxOnlineGeocodingService.h
+++ b/all/native/geocoding/MapBoxOnlineGeocodingService.h
@@ -23,9 +23,9 @@ namespace carto {
     public:
         /**
          * Constructs a new instance of the MapBoxOnlineGeocodingService given API key.
-         * @param apiKey The API key to use registered with MapBox.
+         * @param accessToken The access token to use (registered with MapBox).
          */
-        explicit MapBoxOnlineGeocodingService(const std::string& apiKey);
+        explicit MapBoxOnlineGeocodingService(const std::string& accessToken);
         virtual ~MapBoxOnlineGeocodingService();
 
         /**
@@ -40,14 +40,25 @@ namespace carto {
          */
         void setAutocomplete(bool autocomplete);
 
-        // TODO: language
+        /**
+         * Returns the language of the expected results.
+         * @return The language of the expected results. As ISO 639-1 code or empty string.
+         */
+        std::string getLanguage() const;
+        /**
+         * Sets the language of the expected results.
+         * @param lang The language to use as ISO 639-1 code. Empty string can be used for default language.
+         */
+        void setLanguage(const std::string& lang);
 
         virtual std::vector<std::shared_ptr<GeocodingResult> > calculateAddresses(const std::shared_ptr<GeocodingRequest>& request) const;
 
     protected:
         static const std::string MAPBOX_SERVICE_URL;
 
-        const std::string _apiKey;
+        const std::string _accessToken;
+
+        std::string _language;
 
         bool _autocomplete;
 

--- a/all/native/geocoding/MapBoxOnlineGeocodingService.h
+++ b/all/native/geocoding/MapBoxOnlineGeocodingService.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2016 CartoDB. All rights reserved.
+ * Copying and using this code is allowed only according
+ * to license terms, as given in https://cartodb.com/terms/
+ */
+
+#ifndef _CARTO_MAPBOXONLINEGEOCODINGSERVICE_H_
+#define _CARTO_MAPBOXONLINEGEOCODINGSERVICE_H_
+
+#if defined(_CARTO_GEOCODING_SUPPORT)
+
+#include "geocoding/GeocodingService.h"
+
+namespace carto {
+
+    /**
+     * An online geocoding service that uses MapBox geocoder.
+     * As the class connects to an external (non-CARTO) service, this class is provided "as-is",
+     * future changes from the service provider may not be compatible with the implementation.
+     * Note: this class is experimental and may change or even be removed in future SDK versions.
+     */
+    class MapBoxOnlineGeocodingService : public GeocodingService {
+    public:
+        /**
+         * Constructs a new instance of the MapBoxOnlineGeocodingService given API key.
+         * @param apiKey The API key to use registered with MapBox.
+         */
+        explicit MapBoxOnlineGeocodingService(const std::string& apiKey);
+        virtual ~MapBoxOnlineGeocodingService();
+
+        /**
+         * Returns the autocomplete flag of the service.
+         * @return The autocomplete flag of the service.
+         */
+        bool isAutocomplete() const;
+        /**
+         * Sets the autocomplete flag of the service.
+         * By default this flag is off.
+         * @param autocomplete The new value for autocomplete flag.
+         */
+        void setAutocomplete(bool autocomplete);
+
+        // TODO: language
+
+        virtual std::vector<std::shared_ptr<GeocodingResult> > calculateAddresses(const std::shared_ptr<GeocodingRequest>& request) const;
+
+    protected:
+        static const std::string MAPBOX_SERVICE_URL;
+
+        const std::string _apiKey;
+
+        bool _autocomplete;
+
+        mutable std::mutex _mutex;
+    };
+    
+}
+
+#endif
+
+#endif

--- a/all/native/geocoding/MapBoxOnlineReverseGeocodingService.cpp
+++ b/all/native/geocoding/MapBoxOnlineReverseGeocodingService.cpp
@@ -1,0 +1,62 @@
+#if defined(_CARTO_GEOCODING_SUPPORT)
+
+#include "MapBoxOnlineReverseGeocodingService.h"
+#include "core/BinaryData.h"
+#include "components/Exceptions.h"
+#include "geocoding/MapBoxGeocodingProxy.h"
+#include "projections/Projection.h"
+#include "utils/NetworkUtils.h"
+#include "utils/Log.h"
+
+#include <map>
+
+#include <boost/lexical_cast.hpp>
+
+namespace carto {
+
+    MapBoxOnlineReverseGeocodingService::MapBoxOnlineReverseGeocodingService(const std::string& apiKey) :
+        _apiKey(apiKey),
+        _mutex()
+    {
+    }
+
+    MapBoxOnlineReverseGeocodingService::~MapBoxOnlineReverseGeocodingService() {
+    }
+
+    std::vector<std::shared_ptr<GeocodingResult> > MapBoxOnlineReverseGeocodingService::calculateAddresses(const std::shared_ptr<ReverseGeocodingRequest>& request) const {
+        if (!request) {
+            throw NullArgumentException("Null request");
+        }
+
+        MapPos point = request->getProjection()->toWgs84(request->getLocation());
+        std::string baseURL = MAPBOX_SERVICE_URL + NetworkUtils::URLEncode(boost::lexical_cast<std::string>(point.getY()) + "," + boost::lexical_cast<std::string>(point.getX())) + ".json";
+
+        std::map<std::string, std::string> params;
+        {
+            std::lock_guard<std::mutex> lock(_mutex);
+            params["access_token"] = _apiKey;
+            // TODO: language
+        }
+
+        std::string url = NetworkUtils::BuildURLFromParameters(baseURL, params);
+        Log::Debugf("MapBoxOnlineReverseGeocodingService::calculateAddresses: Loading %s", url.c_str());
+
+        std::shared_ptr<BinaryData> responseData;
+        if (!NetworkUtils::GetHTTP(url, responseData, Log::IsShowDebug())) {
+            throw NetworkException("Failed to fetch response");
+        }
+
+        std::string responseString;
+        if (responseData) {
+            responseString = std::string(reinterpret_cast<const char*>(responseData->data()), responseData->size());
+        } else {
+            throw GenericException("Empty response");
+        }
+
+        return MapBoxGeocodingProxy::ReadResponse(responseString, request->getProjection());
+    }
+
+    const std::string MapBoxOnlineReverseGeocodingService::MAPBOX_SERVICE_URL = "https://api.mapbox.com/geocoding/v5/mapbox.places/";
+}
+
+#endif

--- a/all/native/geocoding/MapBoxOnlineReverseGeocodingService.cpp
+++ b/all/native/geocoding/MapBoxOnlineReverseGeocodingService.cpp
@@ -29,7 +29,7 @@ namespace carto {
         }
 
         MapPos point = request->getProjection()->toWgs84(request->getLocation());
-        std::string baseURL = MAPBOX_SERVICE_URL + NetworkUtils::URLEncode(boost::lexical_cast<std::string>(point.getY()) + "," + boost::lexical_cast<std::string>(point.getX())) + ".json";
+        std::string baseURL = MAPBOX_SERVICE_URL + NetworkUtils::URLEncode(boost::lexical_cast<std::string>(point.getX()) + "," + boost::lexical_cast<std::string>(point.getY())) + ".json";
 
         std::map<std::string, std::string> params;
         {

--- a/all/native/geocoding/MapBoxOnlineReverseGeocodingService.cpp
+++ b/all/native/geocoding/MapBoxOnlineReverseGeocodingService.cpp
@@ -65,6 +65,7 @@ namespace carto {
 
             baseURL = GeneralUtils::ReplaceTags(_serviceURL.empty() ? MAPBOX_SERVICE_URL : _serviceURL, tagMap);
 
+            params["types"] = "address,poi";
             if (!_language.empty()) {
                 params["language"] = _language;
             }
@@ -88,7 +89,7 @@ namespace carto {
         return MapBoxGeocodingProxy::ReadResponse(responseString, request->getProjection());
     }
 
-    const std::string MapBoxOnlineReverseGeocodingService::MAPBOX_SERVICE_URL = "https://api.mapbox.com/geocoding/v5/mapbox.places/{query}.json&access_token={access_token}";
+    const std::string MapBoxOnlineReverseGeocodingService::MAPBOX_SERVICE_URL = "https://api.mapbox.com/geocoding/v5/mapbox.places/{query}.json?access_token={access_token}";
 }
 
 #endif

--- a/all/native/geocoding/MapBoxOnlineReverseGeocodingService.cpp
+++ b/all/native/geocoding/MapBoxOnlineReverseGeocodingService.cpp
@@ -14,8 +14,9 @@
 
 namespace carto {
 
-    MapBoxOnlineReverseGeocodingService::MapBoxOnlineReverseGeocodingService(const std::string& apiKey) :
-        _apiKey(apiKey),
+    MapBoxOnlineReverseGeocodingService::MapBoxOnlineReverseGeocodingService(const std::string& accessToken) :
+        _accessToken(accessToken),
+        _language(),
         _mutex()
     {
     }
@@ -23,6 +24,16 @@ namespace carto {
     MapBoxOnlineReverseGeocodingService::~MapBoxOnlineReverseGeocodingService() {
     }
 
+    std::string MapBoxOnlineReverseGeocodingService::getLanguage() const {
+        std::lock_guard<std::mutex> lock(_mutex);
+        return _language;
+    }
+
+    void MapBoxOnlineReverseGeocodingService::setLanguage(const std::string& lang) {
+        std::lock_guard<std::mutex> lock(_mutex);
+        _language = lang;
+    }
+    
     std::vector<std::shared_ptr<GeocodingResult> > MapBoxOnlineReverseGeocodingService::calculateAddresses(const std::shared_ptr<ReverseGeocodingRequest>& request) const {
         if (!request) {
             throw NullArgumentException("Null request");
@@ -34,8 +45,10 @@ namespace carto {
         std::map<std::string, std::string> params;
         {
             std::lock_guard<std::mutex> lock(_mutex);
-            params["access_token"] = _apiKey;
-            // TODO: language
+            params["access_token"] = _accessToken;
+            if (!_language.empty()) {
+                params["language"] = _language;
+            }
         }
 
         std::string url = NetworkUtils::BuildURLFromParameters(baseURL, params);

--- a/all/native/geocoding/MapBoxOnlineReverseGeocodingService.h
+++ b/all/native/geocoding/MapBoxOnlineReverseGeocodingService.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2016 CartoDB. All rights reserved.
+ * Copying and using this code is allowed only according
+ * to license terms, as given in https://cartodb.com/terms/
+ */
+
+#ifndef _CARTO_MAPBOXONLINEREVERSEGEOCODINGSERVICE_H_
+#define _CARTO_MAPBOXONLINEREVERSEGEOCODINGSERVICE_H_
+
+#if defined(_CARTO_GEOCODING_SUPPORT)
+
+#include "geocoding/ReverseGeocodingService.h"
+
+namespace carto {
+
+    /**
+     * An online reverse geocoding service that uses MapBox geocoder.
+     * As the class connects to an external (non-CARTO) service, this class is provided "as-is",   
+     * future changes from the service provider may not be compatible with the implementation.
+     * Note: this class is experimental and may change or even be removed in future SDK versions.
+     */
+    class MapBoxOnlineReverseGeocodingService : public ReverseGeocodingService {
+    public:
+        /**
+         * Constructs a new instance of the MapBoxOnlineReverseGeocodingService given API key.
+         * @param apiKey The API key to use registered with MapBox.
+         */
+        explicit MapBoxOnlineReverseGeocodingService(const std::string& apiKey);
+        virtual ~MapBoxOnlineReverseGeocodingService();
+
+        // TODO: language
+
+        virtual std::vector<std::shared_ptr<GeocodingResult> > calculateAddresses(const std::shared_ptr<ReverseGeocodingRequest>& request) const;
+
+    protected:
+        static const std::string MAPBOX_SERVICE_URL;
+
+        const std::string _apiKey;
+
+        mutable std::mutex _mutex;
+    };
+    
+}
+
+#endif
+
+#endif

--- a/all/native/geocoding/MapBoxOnlineReverseGeocodingService.h
+++ b/all/native/geocoding/MapBoxOnlineReverseGeocodingService.h
@@ -23,19 +23,30 @@ namespace carto {
     public:
         /**
          * Constructs a new instance of the MapBoxOnlineReverseGeocodingService given API key.
-         * @param apiKey The API key to use registered with MapBox.
+         * @param accessToken The access token to use (registered with MapBox).
          */
-        explicit MapBoxOnlineReverseGeocodingService(const std::string& apiKey);
+        explicit MapBoxOnlineReverseGeocodingService(const std::string& accessToken);
         virtual ~MapBoxOnlineReverseGeocodingService();
 
-        // TODO: language
+        /**
+         * Returns the language of the expected results.
+         * @return The language of the expected results. As ISO 639-1 code or empty string.
+         */
+        std::string getLanguage() const;
+        /**
+         * Sets the language of the expected results.
+         * @param lang The language to use as ISO 639-1 code. Empty string can be used for default language.
+         */
+        void setLanguage(const std::string& lang);
 
         virtual std::vector<std::shared_ptr<GeocodingResult> > calculateAddresses(const std::shared_ptr<ReverseGeocodingRequest>& request) const;
 
     protected:
         static const std::string MAPBOX_SERVICE_URL;
 
-        const std::string _apiKey;
+        const std::string _accessToken;
+
+        std::string _language;
 
         mutable std::mutex _mutex;
     };

--- a/all/native/geocoding/MapBoxOnlineReverseGeocodingService.h
+++ b/all/native/geocoding/MapBoxOnlineReverseGeocodingService.h
@@ -39,6 +39,18 @@ namespace carto {
          */
         void setLanguage(const std::string& lang);
 
+        /**
+         * Returns the custom backend service URL.
+         * @return The custom backend service URL. If this is not defined, an empty string is returned.
+         */
+        std::string getCustomServiceURL() const;
+        /**
+         * Sets the custom backend service URL. 
+         * The custom URL should contain tags "{query}" and "{access_token}" that will be substituted by the SDK.
+         * @param serviceURL The custom backend service URL to use. If this is empty, then the default service is used.
+         */
+        void setCustomServiceURL(const std::string& serviceURL);
+
         virtual std::vector<std::shared_ptr<GeocodingResult> > calculateAddresses(const std::shared_ptr<ReverseGeocodingRequest>& request) const;
 
     protected:
@@ -47,6 +59,8 @@ namespace carto {
         const std::string _accessToken;
 
         std::string _language;
+
+        std::string _serviceURL;
 
         mutable std::mutex _mutex;
     };

--- a/all/native/geocoding/PeliasGeocodingProxy.h
+++ b/all/native/geocoding/PeliasGeocodingProxy.h
@@ -4,8 +4,8 @@
  * to license terms, as given in https://cartodb.com/terms/
  */
 
-#ifndef _CARTO_GEOCODINGPROXY_H_
-#define _CARTO_GEOCODINGPROXY_H_
+#ifndef _CARTO_PELIASGEOCODINGPROXY_H_
+#define _CARTO_PELIASGEOCODINGPROXY_H_
 
 #ifdef _CARTO_GEOCODING_SUPPORT
 

--- a/all/native/geocoding/PeliasOnlineGeocodingService.cpp
+++ b/all/native/geocoding/PeliasOnlineGeocodingService.cpp
@@ -62,10 +62,10 @@ namespace carto {
             std::lock_guard<std::mutex> lock(_mutex);
 
             std::map<std::string, std::string> tagMap;
+            tagMap["api_key"] = NetworkUtils::URLEncode(_apiKey);
             tagMap["mode"] = _autocomplete ? "autocomplete": "search";
             baseURL = GeneralUtils::ReplaceTags(_serviceURL.empty() ? MAPZEN_SERVICE_URL : _serviceURL, tagMap);
 
-            params["api_key"] = _apiKey;
             params["text"] = request->getQuery();
             if (request->getLocationRadius() > 0) {
                 MapPos focusPoint = request->getProjection()->toWgs84(request->getLocation());
@@ -97,7 +97,7 @@ namespace carto {
         return PeliasGeocodingProxy::ReadResponse(responseString, request->getProjection());
     }
 
-    const std::string PeliasOnlineGeocodingService::MAPZEN_SERVICE_URL = "https://search.mapzen.com/v1/{mode}";
+    const std::string PeliasOnlineGeocodingService::MAPZEN_SERVICE_URL = "https://search.mapzen.com/v1/{mode}?api_key={api_key}";
 }
 
 #endif

--- a/all/native/geocoding/PeliasOnlineGeocodingService.cpp
+++ b/all/native/geocoding/PeliasOnlineGeocodingService.cpp
@@ -5,6 +5,7 @@
 #include "components/Exceptions.h"
 #include "geocoding/PeliasGeocodingProxy.h"
 #include "projections/Projection.h"
+#include "utils/GeneralUtils.h"
 #include "utils/NetworkUtils.h"
 #include "utils/Log.h"
 
@@ -17,6 +18,7 @@ namespace carto {
     PeliasOnlineGeocodingService::PeliasOnlineGeocodingService(const std::string& apiKey) :
         _apiKey(apiKey),
         _autocomplete(false),
+        _serviceURL(),
         _mutex()
     {
     }
@@ -34,6 +36,16 @@ namespace carto {
         _autocomplete = autocomplete;
     }
 
+    std::string PeliasOnlineGeocodingService::getCustomServiceURL() const {
+        std::lock_guard<std::mutex> lock(_mutex);
+        return _serviceURL;
+    }
+
+    void PeliasOnlineGeocodingService::setCustomServiceURL(const std::string& serviceURL) {
+        std::lock_guard<std::mutex> lock(_mutex);
+        _serviceURL = serviceURL;
+    }
+
     std::vector<std::shared_ptr<GeocodingResult> > PeliasOnlineGeocodingService::calculateAddresses(const std::shared_ptr<GeocodingRequest>& request) const {
         if (!request) {
             throw NullArgumentException("Null request");
@@ -44,22 +56,26 @@ namespace carto {
         }
 
         std::string baseURL;
-        {
-            std::lock_guard<std::mutex> lock(_mutex);
-            baseURL = (_autocomplete ? PELIAS_AUTOCOMPLETE_URL : PELIAS_SEARCH_URL);
-        }
 
         std::map<std::string, std::string> params;
-        params["api_key"] = _apiKey;
-        params["text"] = request->getQuery();
-        if (request->getLocationRadius() > 0) {
-            MapPos focusPoint = request->getProjection()->toWgs84(request->getLocation());
-            params["focus.point.lat"] = boost::lexical_cast<std::string>(focusPoint.getY());
-            params["focus.point.lon"] = boost::lexical_cast<std::string>(focusPoint.getX());
-            if (baseURL == PELIAS_SEARCH_URL) {
-                params["boundary.circle.lat"] = boost::lexical_cast<std::string>(focusPoint.getY());
-                params["boundary.circle.lon"] = boost::lexical_cast<std::string>(focusPoint.getX());
-                params["boundary.circle.radius"] = boost::lexical_cast<std::string>(request->getLocationRadius());
+        {
+            std::lock_guard<std::mutex> lock(_mutex);
+
+            std::map<std::string, std::string> tagMap;
+            tagMap["mode"] = _autocomplete ? "autocomplete": "search";
+            baseURL = GeneralUtils::ReplaceTags(_serviceURL.empty() ? MAPZEN_SERVICE_URL : _serviceURL, tagMap);
+
+            params["api_key"] = _apiKey;
+            params["text"] = request->getQuery();
+            if (request->getLocationRadius() > 0) {
+                MapPos focusPoint = request->getProjection()->toWgs84(request->getLocation());
+                params["focus.point.lat"] = boost::lexical_cast<std::string>(focusPoint.getY());
+                params["focus.point.lon"] = boost::lexical_cast<std::string>(focusPoint.getX());
+                if (!_autocomplete) {
+                    params["boundary.circle.lat"] = boost::lexical_cast<std::string>(focusPoint.getY());
+                    params["boundary.circle.lon"] = boost::lexical_cast<std::string>(focusPoint.getX());
+                    params["boundary.circle.radius"] = boost::lexical_cast<std::string>(request->getLocationRadius());
+                }
             }
         }
 
@@ -81,8 +97,7 @@ namespace carto {
         return PeliasGeocodingProxy::ReadResponse(responseString, request->getProjection());
     }
 
-    const std::string PeliasOnlineGeocodingService::PELIAS_AUTOCOMPLETE_URL = "https://search.mapzen.com/v1/autocomplete";
-    const std::string PeliasOnlineGeocodingService::PELIAS_SEARCH_URL = "https://search.mapzen.com/v1/search";
+    const std::string PeliasOnlineGeocodingService::MAPZEN_SERVICE_URL = "https://search.mapzen.com/v1/{mode}";
 }
 
 #endif

--- a/all/native/geocoding/PeliasOnlineGeocodingService.h
+++ b/all/native/geocoding/PeliasOnlineGeocodingService.h
@@ -40,15 +40,28 @@ namespace carto {
          */
         void setAutocomplete(bool autocomplete);
 
+        /**
+         * Returns the custom backend service URL.
+         * @return The custom backend service URL. If this is not defined, an empty string is returned.
+         */
+        std::string getCustomServiceURL() const;
+        /**
+         * Sets the custom backend service URL. 
+         * The custom URL should contain tag "{mode}" which will be set either to "autocomplete" or "search" based on the autocomplete state.
+         * @param serviceURL The custom backend service URL to use. If this is empty, then the default service is used.
+         */
+        void setCustomServiceURL(const std::string& serviceURL);
+
         virtual std::vector<std::shared_ptr<GeocodingResult> > calculateAddresses(const std::shared_ptr<GeocodingRequest>& request) const;
 
     protected:
-        static const std::string PELIAS_AUTOCOMPLETE_URL;
-        static const std::string PELIAS_SEARCH_URL;
+        static const std::string MAPZEN_SERVICE_URL;
 
         const std::string _apiKey;
 
         bool _autocomplete;
+
+        std::string _serviceURL;
 
         mutable std::mutex _mutex;
     };

--- a/all/native/geocoding/PeliasOnlineGeocodingService.h
+++ b/all/native/geocoding/PeliasOnlineGeocodingService.h
@@ -47,6 +47,7 @@ namespace carto {
         std::string getCustomServiceURL() const;
         /**
          * Sets the custom backend service URL. 
+         * The custom URL may contain tag "{api_key}" which will be substituted with the set API key.
          * The custom URL should contain tag "{mode}" which will be set either to "autocomplete" or "search" based on the autocomplete state.
          * @param serviceURL The custom backend service URL to use. If this is empty, then the default service is used.
          */

--- a/all/native/geocoding/PeliasOnlineGeocodingService.h
+++ b/all/native/geocoding/PeliasOnlineGeocodingService.h
@@ -23,7 +23,7 @@ namespace carto {
     public:
         /**
          * Constructs a new instance of the PeliasOnlineGeocodingService given API key.
-         * @param apiKey The API key to use registered with Mapzen.
+         * @param apiKey The API key to use (registered with Mapzen).
          */
         explicit PeliasOnlineGeocodingService(const std::string& apiKey);
         virtual ~PeliasOnlineGeocodingService();

--- a/all/native/geocoding/PeliasOnlineReverseGeocodingService.cpp
+++ b/all/native/geocoding/PeliasOnlineReverseGeocodingService.cpp
@@ -5,6 +5,7 @@
 #include "components/Exceptions.h"
 #include "geocoding/PeliasGeocodingProxy.h"
 #include "projections/Projection.h"
+#include "utils/GeneralUtils.h"
 #include "utils/NetworkUtils.h"
 #include "utils/Log.h"
 
@@ -45,9 +46,10 @@ namespace carto {
 
         std::map<std::string, std::string> params;
         {
-            baseURL = _serviceURL.empty() ? MAPZEN_SERVICE_URL : _serviceURL;
+            std::map<std::string, std::string> tagMap;
+            tagMap["api_key"] = NetworkUtils::URLEncode(_apiKey);
+            baseURL = GeneralUtils::ReplaceTags(_serviceURL.empty() ? MAPZEN_SERVICE_URL : _serviceURL, tagMap);
 
-            params["api_key"] = _apiKey;
             params["point.lat"] = boost::lexical_cast<std::string>(point.getY());
             params["point.lon"] = boost::lexical_cast<std::string>(point.getX());
             params["boundary.circle.lat"] = boost::lexical_cast<std::string>(point.getY());
@@ -73,7 +75,7 @@ namespace carto {
         return PeliasGeocodingProxy::ReadResponse(responseString, request->getProjection());
     }
 
-    const std::string PeliasOnlineReverseGeocodingService::MAPZEN_SERVICE_URL = "https://search.mapzen.com/v1/reverse";
+    const std::string PeliasOnlineReverseGeocodingService::MAPZEN_SERVICE_URL = "https://search.mapzen.com/v1/reverse?api_key={api_key}";
 }
 
 #endif

--- a/all/native/geocoding/PeliasOnlineReverseGeocodingService.h
+++ b/all/native/geocoding/PeliasOnlineReverseGeocodingService.h
@@ -28,12 +28,27 @@ namespace carto {
         explicit PeliasOnlineReverseGeocodingService(const std::string& apiKey);
         virtual ~PeliasOnlineReverseGeocodingService();
 
+        /**
+         * Returns the custom backend service URL.
+         * @return The custom backend service URL. If this is not defined, an empty string is returned.
+         */
+        std::string getCustomServiceURL() const;
+        /**
+         * Sets the custom backend service URL. 
+         * @param serviceURL The custom backend service URL to use. If this is empty, then the default service is used.
+         */
+        void setCustomServiceURL(const std::string& serviceURL);
+
         virtual std::vector<std::shared_ptr<GeocodingResult> > calculateAddresses(const std::shared_ptr<ReverseGeocodingRequest>& request) const;
 
     protected:
-        static const std::string PELIAS_REVERSE_URL;
+        static const std::string MAPZEN_SERVICE_URL;
+
+        std::string _serviceURL;
 
         const std::string _apiKey;
+
+        mutable std::mutex _mutex;
     };
     
 }

--- a/all/native/geocoding/PeliasOnlineReverseGeocodingService.h
+++ b/all/native/geocoding/PeliasOnlineReverseGeocodingService.h
@@ -23,7 +23,7 @@ namespace carto {
     public:
         /**
          * Constructs a new instance of the PeliasOnlineReverseGeocodingService given API key.
-         * @param apiKey The API key to use registered with Mapzen.
+         * @param apiKey The API key to use (registered with Mapzen).
          */
         explicit PeliasOnlineReverseGeocodingService(const std::string& apiKey);
         virtual ~PeliasOnlineReverseGeocodingService();

--- a/all/native/geocoding/PeliasOnlineReverseGeocodingService.h
+++ b/all/native/geocoding/PeliasOnlineReverseGeocodingService.h
@@ -35,6 +35,7 @@ namespace carto {
         std::string getCustomServiceURL() const;
         /**
          * Sets the custom backend service URL. 
+         * The custom URL may contain tag "{api_key}" which will be substituted with the set API key.
          * @param serviceURL The custom backend service URL to use. If this is empty, then the default service is used.
          */
         void setCustomServiceURL(const std::string& serviceURL);

--- a/all/native/packagemanager/PackageManager.cpp
+++ b/all/native/packagemanager/PackageManager.cpp
@@ -228,8 +228,8 @@ namespace carto {
                     auto packageInfo = std::make_shared<PackageInfo>(
                         packageId,
                         packageType,
-                        jsonPackageInfo["version"].GetInt(),
-                        jsonPackageInfo["size"].GetInt64(),
+                        jsonPackageInfo["version"].IsString() ? boost::lexical_cast<int>(jsonPackageInfo["version"].GetString()) : jsonPackageInfo["version"].GetInt(),
+                        jsonPackageInfo["size"].IsString() ? boost::lexical_cast<std::uint64_t>(jsonPackageInfo["size"].GetString()) : jsonPackageInfo["size"].GetInt64(),
                         packageURL,
                         tileMask,
                         metaInfo

--- a/all/native/routing/CartoOnlineRoutingService.cpp
+++ b/all/native/routing/CartoOnlineRoutingService.cpp
@@ -4,7 +4,7 @@
 #include "components/Exceptions.h"
 #include "components/LicenseManager.h"
 #include "projections/Projection.h"
-#include "routing/RoutingProxy.h"
+#include "routing/OSRMRoutingProxy.h"
 #include "network/HTTPClient.h"
 #include "utils/Log.h"
 #include "utils/PlatformUtils.h"
@@ -52,7 +52,7 @@ namespace carto {
         Log::Debugf("CartoOnlineRoutingService::calculateRoute: Loading %s", url.c_str());
 
         HTTPClient httpClient(Log::IsShowDebug());
-        return RoutingProxy::CalculateRoute(httpClient, url, request);
+        return OSRMRoutingProxy::CalculateRoute(httpClient, url, request);
     }
 
     const std::string CartoOnlineRoutingService::ROUTING_SERVICE_URL = "http://mobile-api.carto.com/routing/v2/";

--- a/all/native/routing/OSRMOfflineRoutingService.cpp
+++ b/all/native/routing/OSRMOfflineRoutingService.cpp
@@ -3,7 +3,7 @@
 #include "OSRMOfflineRoutingService.h"
 #include "components/Exceptions.h"
 #include "projections/Projection.h"
-#include "routing/RoutingProxy.h"
+#include "routing/OSRMRoutingProxy.h"
 #include "utils/Const.h"
 #include "utils/Log.h"
 
@@ -39,7 +39,7 @@ namespace carto {
             throw NullArgumentException("Null request");
         }
 
-        return RoutingProxy::CalculateRoute(_routeFinder, request);
+        return OSRMRoutingProxy::CalculateRoute(_routeFinder, request);
     }
 
 }

--- a/all/native/routing/OSRMRoutingProxy.cpp
+++ b/all/native/routing/OSRMRoutingProxy.cpp
@@ -1,6 +1,6 @@
 #ifdef _CARTO_ROUTING_SUPPORT
 
-#include "RoutingProxy.h"
+#include "OSRMRoutingProxy.h"
 #include "core/BinaryData.h"
 #include "components/Exceptions.h"
 #include "projections/Projection.h"
@@ -24,7 +24,7 @@
 
 namespace carto {
 
-    std::shared_ptr<RoutingResult> RoutingProxy::CalculateRoute(const std::shared_ptr<routing::RouteFinder>& routeFinder, const std::shared_ptr<RoutingRequest>& request) {
+    std::shared_ptr<RoutingResult> OSRMRoutingProxy::CalculateRoute(const std::shared_ptr<routing::RouteFinder>& routeFinder, const std::shared_ptr<RoutingRequest>& request) {
         std::shared_ptr<Projection> proj = request->getProjection();
         EPSG3857 epsg3857;
 
@@ -90,7 +90,7 @@ namespace carto {
         return std::make_shared<RoutingResult>(proj, points, instructions);
     }
 
-    std::shared_ptr<RoutingResult> RoutingProxy::CalculateRoute(HTTPClient& httpClient, const std::string& url, const std::shared_ptr<RoutingRequest>& request) {
+    std::shared_ptr<RoutingResult> OSRMRoutingProxy::CalculateRoute(HTTPClient& httpClient, const std::string& url, const std::shared_ptr<RoutingRequest>& request) {
         std::shared_ptr<Projection> proj = request->getProjection();
         EPSG3857 epsg3857;
         
@@ -155,7 +155,7 @@ namespace carto {
         return std::make_shared<RoutingResult>(proj, points, instructions);
     }
     
-    float RoutingProxy::CalculateTurnAngle(const std::vector<MapPos>& epsg3857Points, int pointIndex) {
+    float OSRMRoutingProxy::CalculateTurnAngle(const std::vector<MapPos>& epsg3857Points, int pointIndex) {
         int pointIndex0 = pointIndex;
         while (--pointIndex0 >= 0) {
             if (epsg3857Points.at(pointIndex0) != epsg3857Points.at(pointIndex)) {
@@ -182,7 +182,7 @@ namespace carto {
         return turnAngle;
     }
     
-    float RoutingProxy::CalculateAzimuth(const std::vector<MapPos>& epsg3857Points, int pointIndex) {
+    float OSRMRoutingProxy::CalculateAzimuth(const std::vector<MapPos>& epsg3857Points, int pointIndex) {
         int step = 1;
         for (int i = pointIndex; i >= 0; i += step) {
             if (i + 1 >= static_cast<int>(epsg3857Points.size())) {
@@ -201,7 +201,7 @@ namespace carto {
         return std::numeric_limits<float>::quiet_NaN();
     }
     
-    bool RoutingProxy::TranslateInstructionCode(int instructionCode, RoutingAction::RoutingAction& action) {
+    bool OSRMRoutingProxy::TranslateInstructionCode(int instructionCode, RoutingAction::RoutingAction& action) {
         switch (static_cast<routing::Instruction::Type>(instructionCode)) {
             case routing::Instruction::Type::NO_TURN:
                 action = RoutingAction::ROUTING_ACTION_NO_TURN;
@@ -247,13 +247,13 @@ namespace carto {
                 action = RoutingAction::ROUTING_ACTION_FINISH;
                 break;
             default:
-                Log::Infof("RoutingProxy::TranslateInstructionCode: ignoring instruction %d", instructionCode);
+                Log::Infof("OSRMRoutingProxy::TranslateInstructionCode: ignoring instruction %d", instructionCode);
                 return false;
         }
         return true;
     }
 
-    std::vector<MapPos> RoutingProxy::DecodeGeometry(const std::string& encodedGeometry) {
+    std::vector<MapPos> OSRMRoutingProxy::DecodeGeometry(const std::string& encodedGeometry) {
         std::vector<MapPos> points;
         points.reserve(encodedGeometry.size());
         int lat = 0;
@@ -285,10 +285,10 @@ namespace carto {
         return points;
     }
     
-    RoutingProxy::RoutingProxy() {
+    OSRMRoutingProxy::OSRMRoutingProxy() {
     }
     
-    const double RoutingProxy::COORDINATE_SCALE = 1.0e-6;
+    const double OSRMRoutingProxy::COORDINATE_SCALE = 1.0e-6;
     
 }
 

--- a/all/native/routing/OSRMRoutingProxy.h
+++ b/all/native/routing/OSRMRoutingProxy.h
@@ -4,8 +4,8 @@
  * to license terms, as given in https://cartodb.com/terms/
  */
 
-#ifndef _CARTO_ROUTINGPROXY_H_
-#define _CARTO_ROUTINGPROXY_H_
+#ifndef _CARTO_OSRMROUTINGPROXY_H_
+#define _CARTO_OSRMROUTINGPROXY_H_
 
 #ifdef _CARTO_ROUTING_SUPPORT
 
@@ -23,14 +23,14 @@ namespace carto {
     
     class HTTPClient;
 
-    class RoutingProxy {
+    class OSRMRoutingProxy {
     public:
         static std::shared_ptr<RoutingResult> CalculateRoute(const std::shared_ptr<routing::RouteFinder>& routeFinder, const std::shared_ptr<RoutingRequest>& request);
         
         static std::shared_ptr<RoutingResult> CalculateRoute(HTTPClient& httpClient, const std::string& url, const std::shared_ptr<RoutingRequest>& request);
 
     private:
-        RoutingProxy();
+        OSRMRoutingProxy();
         
         static float CalculateTurnAngle(const std::vector<MapPos>& epsg3857Points, int pointIndex);
         

--- a/all/native/routing/PackageManagerRoutingService.cpp
+++ b/all/native/routing/PackageManagerRoutingService.cpp
@@ -5,7 +5,7 @@
 #include "packagemanager/PackageInfo.h"
 #include "packagemanager/handlers/RoutingPackageHandler.h"
 #include "projections/Projection.h"
-#include "routing/RoutingProxy.h"
+#include "routing/OSRMRoutingProxy.h"
 #include "utils/Const.h"
 #include "utils/Log.h"
 
@@ -74,7 +74,7 @@ namespace carto {
                 _cachedRouteFinder = std::make_shared<routing::RouteFinder>(graph);
             }
 
-            result = RoutingProxy::CalculateRoute(_cachedRouteFinder, request);
+            result = OSRMRoutingProxy::CalculateRoute(_cachedRouteFinder, request);
         });
 
         return result;

--- a/all/native/routing/ValhallaOnlineRoutingService.cpp
+++ b/all/native/routing/ValhallaOnlineRoutingService.cpp
@@ -3,6 +3,7 @@
 #include "ValhallaOnlineRoutingService.h"
 #include "components/Exceptions.h"
 #include "routing/ValhallaRoutingProxy.h"
+#include "utils/GeneralUtils.h"
 #include "utils/NetworkUtils.h"
 #include "utils/Log.h"
 
@@ -13,6 +14,7 @@ namespace carto {
     ValhallaOnlineRoutingService::ValhallaOnlineRoutingService(const std::string& apiKey) :
         _apiKey(apiKey),
         _profile("pedestrian"),
+        _serviceURL(),
         _mutex()
     {
     }
@@ -30,18 +32,37 @@ namespace carto {
         _profile = profile;
     }
 
+    std::string ValhallaOnlineRoutingService::getCustomServiceURL() const {
+        std::lock_guard<std::mutex> lock(_mutex);
+        return _serviceURL;
+    }
+
+    void ValhallaOnlineRoutingService::setCustomServiceURL(const std::string& serviceURL) {
+        std::lock_guard<std::mutex> lock(_mutex);
+        _serviceURL = serviceURL;
+    }
+
     std::shared_ptr<RoutingResult> ValhallaOnlineRoutingService::calculateRoute(const std::shared_ptr<RoutingRequest>& request) const {
         if (!request) {
             throw NullArgumentException("Null request");
         }
 
+        std::string baseURL;
+
         std::map<std::string, std::string> params;
-        params["api_key"] = _apiKey;
-        std::string url = NetworkUtils::BuildURLFromParameters(VALHALLA_ROUTING_URL, params);
+        {
+            std::lock_guard<std::mutex> lock(_mutex);
+
+            std::map<std::string, std::string> tagMap;
+            tagMap["api_key"] = NetworkUtils::URLEncode(_apiKey);
+            baseURL = GeneralUtils::ReplaceTags(_serviceURL.empty() ? MAPZEN_SERVICE_URL : _serviceURL, tagMap);
+        }
+
+        std::string url = NetworkUtils::BuildURLFromParameters(baseURL, params);
         return ValhallaRoutingProxy::CalculateRoute(url, getProfile(), request);
     }
 
-    const std::string ValhallaOnlineRoutingService::VALHALLA_ROUTING_URL = "https://valhalla.mapzen.com/route";
+    const std::string ValhallaOnlineRoutingService::MAPZEN_SERVICE_URL = "https://valhalla.mapzen.com/route?api_key={api_key}";
 
 }
 

--- a/all/native/routing/ValhallaOnlineRoutingService.h
+++ b/all/native/routing/ValhallaOnlineRoutingService.h
@@ -47,14 +47,28 @@ namespace carto {
          */
         void setProfile(const std::string& profile);
 
+        /**
+         * Returns the custom backend service URL.
+         * @return The custom backend service URL. If this is not defined, an empty string is returned.
+         */
+        std::string getCustomServiceURL() const;
+        /**
+         * Sets the custom backend service URL. 
+         * The custom URL may contain tag "{api_key}" which will be substituted with the set API key.
+         * @param serviceURL The custom backend service URL to use. If this is empty, then the default service is used.
+         */
+        void setCustomServiceURL(const std::string& serviceURL);
+
         virtual std::shared_ptr<RoutingResult> calculateRoute(const std::shared_ptr<RoutingRequest>& request) const;
 
     private:
-        static const std::string VALHALLA_ROUTING_URL;
+        static const std::string MAPZEN_SERVICE_URL;
 
         const std::string _apiKey;
 
         std::string _profile;
+
+        std::string _serviceURL;
 
         mutable std::mutex _mutex;
     };

--- a/doc/geocoding.md
+++ b/doc/geocoding.md
@@ -22,7 +22,7 @@ For minimal geocoding implementation, use our sample app code for different mobi
   
 ## Online Geocoding
 
-Online geocoding is available through [Pelias](https://github.com/pelias/pelias). You will need your own Mapzen API key. Sign-up at [https://mapzen.com/](https://mapzen.com/) to receive an API key.
+Online geocoding is available through MapBox's geocoding service. You will need your own Mapbox token. Sign up at [https://www.mapbox.com/](https://www.mapbox.com/) to obtain your token.
 
 Implement online geocoding to initialize the service, create the request, and calculate addresses:
 
@@ -48,7 +48,7 @@ Implement online geocoding to initialize the service, create the request, and ca
   <div class="Carousel-item js-Tabpanes-item--lang js-Tabpanes-item--lang--java is-active">
   {% highlight java %}
   
-PeliasOnlineGeocodingService service = new PeliasOnlineGeocodingService("<your-mapzen-api-key>");
+MapBoxOnlineGeocodingService service = new MapBoxOnlineGeocodingService("<your-mapbox-token>");
 GeocodingRequest request = new GeocodingRequest(mapView.getOptions().getBaseProjection(), "Fifth Avenue, New York");
 
 // Note: Geocoding is a complicated process and should not be done on the main thread
@@ -72,7 +72,7 @@ thread.start();
   <div class="Carousel-item js-Tabpanes-item--lang js-Tabpanes-item--lang--csharp">
   {% highlight csharp %}
 
-Service = new PeliasOnlineGeocodingService("<your-mapzen-api-key>");
+Service = new MapBoxOnlineGeocodingService("<your-mapbox-token>");
 var request = new GeocodingRequest(mapView.Options.BaseProjection, "Fifth Avenue, New York");
 
 // Note: Geocoding is a complicated process and should not be done on the main thread
@@ -84,7 +84,7 @@ GeocodingResultVector results = Service.CalculateAddresses(request);
    <div class="Carousel-item js-Tabpanes-item--lang js-Tabpanes-item--lang--objective-c">
   {% highlight objc %}
   
-NTPeliasOnlineGeocodingService *service = [[NTPeliasOnlineGeocodingService alloc]initWithApiKey:@"<your-mapzen-api-key>"];
+NTMapBoxOnlineGeocodingService *service = [[NTMapBoxOnlineGeocodingService alloc]initWithApiKey:@"<your-mapbox-key>"];
 NTProjection *projection = [[self.mapView getOptions] getBaseProjection];
 NTGeocodingRequest *request = [[NTGeocodingRequest alloc]initWithProjection:projection query:@"text"];
 
@@ -97,7 +97,7 @@ NTGeocodingResultVector *results = [service calculateAddresses:request];
   <div class="Carousel-item js-Tabpanes-item--lang js-Tabpanes-item--lang--swift">
   {% highlight swift %}
   
-let service = NTPeliasOnlineGeocodingService(apiKey: "<your-mapzen-api-key>")
+let service = NTMapBoxOnlineGeocodingService(apiKey: "<your-mapbox-key>")
 let request = NTGeocodingRequest(projection: self.contentView.map.getOptions().getBaseProjection(), query: "Fifth Avenue, New York")
 
 // Note: Geocoding is a complicated process and should not be done on the main thread
@@ -109,7 +109,7 @@ let results = self.service.calculateAddresses(request)
   <div class="Carousel-item js-Tabpanes-item--lang js-Tabpanes-item--lang--kotlin">
   {% highlight kotlin %}
 
-val service = PeliasOnlineGeocodingService("<your-mapzen-api-key>")
+val service = MapBoxOnlineGeocodingService("<your-mapbox-token>")
 val request = GeocodingRequest(map.options.baseProjection, "Fifth Avenue, New York")
 
 // Note: Geocoding is a complicated process and should not be done on the main thread
@@ -125,7 +125,7 @@ From your `GeocodingResult` objects, you can simply access `name`, `locality`, `
 
 ## Reverse Geocoding
 
-Online reverse geocoding is also available through [Pelias](https://github.com/pelias/pelias). You will need your own Mapzen API key. Sign up at [https://mapzen.com/](https://mapzen.com/) to receive an API key.
+Online reverse geocoding is also available through MapBox's geocoding service. You will need your own Mapbox token. Sign up at [https://www.mapbox.com/](https://www.mapbox.com/) obtain your token.
 
 <div class="js-TabPanes">
   <ul class="Tabs">
@@ -149,7 +149,7 @@ Online reverse geocoding is also available through [Pelias](https://github.com/p
   <div class="Carousel-item js-Tabpanes-item--lang js-Tabpanes-item--lang--java is-active">
   {% highlight java %}
 
-service = new PeliasOnlineReverseGeocodingService("<your-mapzen-key>");
+service = new MapBoxOnlineReverseGeocodingService("<your-mapbox-token>");
 
 // Center of New York. Reverse Geocoding these coordinates will find City Hall Park
 MapPos newYork = baseProjection.fromLatLong(40.7128, -74.0059);
@@ -171,7 +171,7 @@ try {
   <div class="Carousel-item js-Tabpanes-item--lang js-Tabpanes-item--lang--csharp">
   {% highlight csharp %}
 
-Service = new PeliasOnlineReverseGeocodingService("<your-mapzen-key>");
+Service = new MapBoxOnlineReverseGeocodingService("<your-mapbox-token>");
 
 // Center of New York. Reverse Geocoding these coordinates will find City Hall Park
 MapPos newYork = projection.FromLatLong(40.7128, -74.0059);
@@ -189,7 +189,7 @@ GeocodingResultVector results = Service.CalculateAddresses(request);
    <div class="Carousel-item js-Tabpanes-item--lang js-Tabpanes-item--lang--objective-c">
   {% highlight objc %}
 
-self.service = [[NTPeliasOnlineReverseGeocodingService alloc]initWithApiKey:@"<mapzen-api-key>"];
+self.service = [[NTMapBoxOnlineReverseGeocodingService alloc]initWithApiKey:@"<mapbox-token>"];
 
 NTProjection *projection = [self.controller getProjection];
 // Center of New York. Reverse Geocoding these coordinates will find City Hall Park
@@ -206,7 +206,7 @@ NTGeocodingResultVector *results = [self.service calculateAddresses: request];
   <div class="Carousel-item js-Tabpanes-item--lang js-Tabpanes-item--lang--swift">
   {% highlight swift %}
 
-service = NTPeliasOnlineReverseGeocodingService(apiKey: "<your-mapzen-key>")
+service = NTMapBoxOnlineReverseGeocodingService(apiKey: "<your-mapbox-token>")
 
 // Center of New York. Reverse Geocoding these coordinates will find City Hall Park
 let newYork = projection.fromLat(40.7128, lng: -74.0059)
@@ -224,7 +224,7 @@ let results = service.calculateAddresses(request)
   <div class="Carousel-item js-Tabpanes-item--lang js-Tabpanes-item--lang--kotlin">
   {% highlight kotlin %}
 
-service = PeliasOnlineReverseGeocodingService("<your-mapzen-key>")
+service = MapBoxOnlineReverseGeocodingService("<your-mapbox-token>")
 
 // Center of New York. Reverse Geocoding these coordinates will find City Hall Park
 val newYork = contentView?.projection?.fromLatLong(40.7128, -74.0059)

--- a/doc/routing.md
+++ b/doc/routing.md
@@ -87,7 +87,7 @@ The following _Online Routing_ and _Offline Routing_ procedures demonstrate the 
  
 Online routing requires that you create a simple call and request to calculate the route.
 
-1) Create the `ValhallaOnlineRoutingService` call
+1) Create the `CartoOnlineRoutingService` call
 
 <div class="js-TabPanes">
   <ul class="Tabs">
@@ -111,8 +111,8 @@ Online routing requires that you create a simple call and request to calculate t
 
   <div class="Carousel-item js-Tabpanes-item--lang js-Tabpanes-item--lang--java is-active">
   {% highlight java %}
-  
-	ValhallaOnlineRoutingService onlineRoutingService = new ValhallaOnlineRoutingService("<your-mapzen-api-key>");
+
+	CartoOnlineRoutingService onlineRoutingService = new CartoOnlineRoutingService("nutiteq.osm.car");
 
   {% endhighlight %}
   </div>
@@ -120,7 +120,7 @@ Online routing requires that you create a simple call and request to calculate t
   <div class="Carousel-item js-Tabpanes-item--lang js-Tabpanes-item--lang--csharp">
   {% highlight csharp %}
   
-	var onlineRoutingService = new ValhallaOnlineRoutingService("<your-mapzen-api-key");
+	var onlineRoutingService = new CartoOnlineRoutingService("nutiteq.osm.car");
 
   {% endhighlight %}
   </div>
@@ -128,7 +128,7 @@ Online routing requires that you create a simple call and request to calculate t
    <div class="Carousel-item js-Tabpanes-item--lang js-Tabpanes-item--lang--objective-c">
   {% highlight objc %}
   
-  	NTValhallaOnlineRoutingService* _onlineRoutingService = [[NTValhallaOnlineRoutingService alloc] initWithApiKey:@"<your-mapzen-api-key>"];
+  	NTCartoOnlineRoutingService* _onlineRoutingService = [[NTCartoOnlineRoutingService alloc] initWithApiKey:@"nutiteq.osm.car"];
 
   {% endhighlight %}
   </div>
@@ -136,7 +136,7 @@ Online routing requires that you create a simple call and request to calculate t
   <div class="Carousel-item js-Tabpanes-item--lang js-Tabpanes-item--lang--swift">
   {% highlight swift %}
   
-	let onlineRoutingService = NTValhallaOnlineRoutingService(apiKey: "<your-mapzen-api-key");
+	let onlineRoutingService = NTCartoOnlineRoutingService(source: "nutiteq.osm.car");
 
   {% endhighlight %}
   </div>
@@ -144,7 +144,7 @@ Online routing requires that you create a simple call and request to calculate t
   <div class="Carousel-item js-Tabpanes-item--lang js-Tabpanes-item--lang--kotlin">
   {% highlight kotlin %}
   
-	val onlineRoutingService = ValhallaOnlineRoutingService("<your-mapzen-api-key>");
+	val onlineRoutingService = CartoOnlineRoutingService("nutiteq.osm.car");
 
   {% endhighlight %}
   </div>

--- a/ios/objc/CartoMobileSDK.h
+++ b/ios/objc/CartoMobileSDK.h
@@ -180,6 +180,7 @@
 #import "NTPeliasOnlineGeocodingService.h"
 #import "NTPeliasOnlineReverseGeocodingService.h"
 #import "NTMapBoxOnlineGeocodingService.h"
+#import "NTMapBoxOnlineReverseGeocodingService.h"
 #endif
 
 #ifdef _CARTO_SEARCH_SUPPORT

--- a/ios/objc/CartoMobileSDK.h
+++ b/ios/objc/CartoMobileSDK.h
@@ -179,6 +179,7 @@
 #import "NTOSMOfflineReverseGeocodingService.h"
 #import "NTPeliasOnlineGeocodingService.h"
 #import "NTPeliasOnlineReverseGeocodingService.h"
+#import "NTMapBoxOnlineGeocodingService.h"
 #endif
 
 #ifdef _CARTO_SEARCH_SUPPORT

--- a/scripts/build-xamarin.py
+++ b/scripts/build-xamarin.py
@@ -127,6 +127,7 @@ def buildXamarinNuget(args, target):
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--profile', dest='profile', default='standard', type=validProfile, help='Build profile')
+parser.add_argument('--android-abi', dest='androidabi', default=[], choices=ANDROID_ABIS + ['all'], action='append', help='Android target ABIs')
 parser.add_argument('--defines', dest='defines', default='', help='Defines for compilation')
 parser.add_argument('--xbuild', dest='xbuild', default='xbuild', help='Xamarin xbuild executable')
 parser.add_argument('--nuget', dest='nuget', default='nuget', help='nuget executable')
@@ -141,6 +142,8 @@ parser.add_argument('--build-nuget', dest='buildnuget', default=False, action='s
 parser.add_argument(dest='target', choices=['android', 'ios'], help='Target platform')
 
 args = parser.parse_args()
+if 'all' in args.androidabi or args.androidabi == []:
+  args.androidabi = ANDROID_ABIS
 if args.xbuild == 'auto':
   args.xbuild = DEFAULT_XBUILD
 elif args.xbuild == 'none':
@@ -162,7 +165,7 @@ args.nativeconfiguration = args.configuration
 target = None
 if args.target == 'android':
   target = 'Android'
-  for abi in ANDROID_ABIS:
+  for abi in args.androidabi:
     if not buildAndroidSO(args, abi):
       exit(-1)
 elif args.target == 'ios':

--- a/scripts/xamarin/CartoMobileSDK.Android.csproj.template
+++ b/scripts/xamarin/CartoMobileSDK.Android.csproj.template
@@ -80,25 +80,9 @@
       <Abi>armeabi-v7a</Abi>
       <Link>armeabi-v7a\libcarto_mobile_sdk.so</Link>
     </EmbeddedNativeLibrary>
-    <EmbeddedNativeLibrary Include="$baseDir\prebuilt\gdal\libs\armeabi-v7a\libgdal.so">
-      <Abi>armeabi-v7a</Abi>
-      <Link>armeabi-v7a\libgdal.so</Link>
-    </EmbeddedNativeLibrary>
-    <EmbeddedNativeLibrary Include="$baseDir\prebuilt\gdal\libs\armeabi-v7a\libproj.so">
-      <Abi>armeabi-v7a</Abi>
-      <Link>armeabi-v7a\libproj.so</Link>
-    </EmbeddedNativeLibrary>
     <EmbeddedNativeLibrary Include="$buildDir\..\xamarin_android-x86\libcarto_mobile_sdk.so">
       <Abi>x86</Abi>
       <Link>x86\libcarto_mobile_sdk.so</Link>
-    </EmbeddedNativeLibrary>
-    <EmbeddedNativeLibrary Include="$baseDir\prebuilt\gdal\libs\x86\libgdal.so">
-      <Abi>x86</Abi>
-      <Link>x86\libgdal.so</Link>
-    </EmbeddedNativeLibrary>
-    <EmbeddedNativeLibrary Include="$baseDir\prebuilt\gdal\libs\x86\libproj.so">
-      <Abi>x86</Abi>
-      <Link>x86\libproj.so</Link>
     </EmbeddedNativeLibrary>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Novell\Novell.MonoDroid.CSharp.targets" />

--- a/scripts/xamarin/CartoMobileSDK.Android.csproj.template
+++ b/scripts/xamarin/CartoMobileSDK.Android.csproj.template
@@ -76,6 +76,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <EmbeddedNativeLibrary Include="$buildDir\..\xamarin_android-armeabi\libcarto_mobile_sdk.so">
+      <Abi>armeabi</Abi>
+      <Link>armeabi\libcarto_mobile_sdk.so</Link>
+    </EmbeddedNativeLibrary>
     <EmbeddedNativeLibrary Include="$buildDir\..\xamarin_android-armeabi-v7a\libcarto_mobile_sdk.so">
       <Abi>armeabi-v7a</Abi>
       <Link>armeabi-v7a\libcarto_mobile_sdk.so</Link>
@@ -84,6 +88,14 @@
       <Abi>x86</Abi>
       <Link>x86\libcarto_mobile_sdk.so</Link>
     </EmbeddedNativeLibrary>
+    <EmbeddedNativeLibrary Include="$buildDir\..\xamarin_android-arm64-v8a\libcarto_mobile_sdk.so">
+      <Abi>arm64-v8a</Abi>
+      <Link>arm64-v8a\libcarto_mobile_sdk.so</Link>
+    </EmbeddedNativeLibrary>
+    <EmbeddedNativeLibrary Include="$buildDir\..\xamarin_android-x86_64\libcarto_mobile_sdk.so">
+      <Abi>x86_64</Abi>
+      <Link>x86_64\libcarto_mobile_sdk.so</Link>
+    </EmbeddedNativeLibrary>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Novell\Novell.MonoDroid.CSharp.targets" />
   <ItemGroup>
@@ -91,7 +103,10 @@
     <Folder Include="UI\" />
     <Folder Include="PackageManager\" />
     <Folder Include="Properties\" />
+    <Folder Include="armeabi\" />
     <Folder Include="armeabi-v7a\" />
     <Folder Include="x86\" />
+    <Folder Include="arm64-v8a\" />
+    <Folder Include="x86_64\" />
   </ItemGroup>
 </Project>

--- a/scripts/xamarin/CartoMobileSDK.Android.csproj.template
+++ b/scripts/xamarin/CartoMobileSDK.Android.csproj.template
@@ -80,9 +80,25 @@
       <Abi>armeabi-v7a</Abi>
       <Link>armeabi-v7a\libcarto_mobile_sdk.so</Link>
     </EmbeddedNativeLibrary>
+    <EmbeddedNativeLibrary Include="$baseDir\prebuilt\gdal\libs\armeabi-v7a\libgdal.so">
+      <Abi>armeabi-v7a</Abi>
+      <Link>armeabi-v7a\libgdal.so</Link>
+    </EmbeddedNativeLibrary>
+    <EmbeddedNativeLibrary Include="$baseDir\prebuilt\gdal\libs\armeabi-v7a\libproj.so">
+      <Abi>armeabi-v7a</Abi>
+      <Link>armeabi-v7a\libproj.so</Link>
+    </EmbeddedNativeLibrary>
     <EmbeddedNativeLibrary Include="$buildDir\..\xamarin_android-x86\libcarto_mobile_sdk.so">
       <Abi>x86</Abi>
       <Link>x86\libcarto_mobile_sdk.so</Link>
+    </EmbeddedNativeLibrary>
+    <EmbeddedNativeLibrary Include="$baseDir\prebuilt\gdal\libs\x86\libgdal.so">
+      <Abi>x86</Abi>
+      <Link>x86\libgdal.so</Link>
+    </EmbeddedNativeLibrary>
+    <EmbeddedNativeLibrary Include="$baseDir\prebuilt\gdal\libs\x86\libproj.so">
+      <Abi>x86</Abi>
+      <Link>x86\libproj.so</Link>
     </EmbeddedNativeLibrary>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Novell\Novell.MonoDroid.CSharp.targets" />

--- a/scripts/xamarin/CartoMobileSDK.Android.csproj.template
+++ b/scripts/xamarin/CartoMobileSDK.Android.csproj.template
@@ -76,10 +76,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <EmbeddedNativeLibrary Include="$buildDir\..\xamarin_android-armeabi\libcarto_mobile_sdk.so">
-      <Abi>armeabi</Abi>
-      <Link>armeabi\libcarto_mobile_sdk.so</Link>
-    </EmbeddedNativeLibrary>
     <EmbeddedNativeLibrary Include="$buildDir\..\xamarin_android-armeabi-v7a\libcarto_mobile_sdk.so">
       <Abi>armeabi-v7a</Abi>
       <Link>armeabi-v7a\libcarto_mobile_sdk.so</Link>
@@ -88,14 +84,6 @@
       <Abi>x86</Abi>
       <Link>x86\libcarto_mobile_sdk.so</Link>
     </EmbeddedNativeLibrary>
-    <EmbeddedNativeLibrary Include="$buildDir\..\xamarin_android-arm64-v8a\libcarto_mobile_sdk.so">
-      <Abi>arm64-v8a</Abi>
-      <Link>arm64-v8a\libcarto_mobile_sdk.so</Link>
-    </EmbeddedNativeLibrary>
-    <EmbeddedNativeLibrary Include="$buildDir\..\xamarin_android-x86_64\libcarto_mobile_sdk.so">
-      <Abi>x86_64</Abi>
-      <Link>x86_64\libcarto_mobile_sdk.so</Link>
-    </EmbeddedNativeLibrary>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Novell\Novell.MonoDroid.CSharp.targets" />
   <ItemGroup>
@@ -103,10 +91,7 @@
     <Folder Include="UI\" />
     <Folder Include="PackageManager\" />
     <Folder Include="Properties\" />
-    <Folder Include="armeabi\" />
     <Folder Include="armeabi-v7a\" />
     <Folder Include="x86\" />
-    <Folder Include="arm64-v8a\" />
-    <Folder Include="x86_64\" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
For 4.1.2-RC1. Notes from @mtehver :

New features:
* SDK has support for MapBox online geocoding services.
 New classes MapBoxOnlineGeocodingService and MapBoxOnlineReverseGeocodingService can be used for this.
* All MapZen online service (Pelias and Valhalla) wrappers now include additional methods for specifying custom service URLs.
 This feature was added as MapZen closes all online services as of February 2018.

Fixes/changes:
* Smaller built-in style asset due to optimized fonts
* SDK includes latest version of CARTO styles
* Improved text placement along lines in vector tile renderer
* Fixed text wrapping in vector tile renderer when ‘wrap-before: true’ mode was used
* MapZen-specific code was removed from CartoOnlineVectorLayer
* Minor optimizations in vector tile renderer for transparent features