### PR TITLE
first version of OrderedTileDataSource (between only 2 sources)

### DIFF
--- a/all/modules/datasources/OrderedTileDataSource.i
+++ b/all/modules/datasources/OrderedTileDataSource.i
@@ -1,0 +1,28 @@
+#ifndef _OrderedTileDataSource_I
+#define _OrderedTileDataSource_I
+
+%module(directors="1") OrderedTileDataSource
+
+!proxy_imports(carto::OrderedTileDataSource, core.MapTile, core.MapBounds, core.StringMap, datasources.TileDataSource, datasources.components.TileData)
+
+%{
+#include "datasources/OrderedTileDataSource.h"
+#include "components/Exceptions.h"
+#include <memory>
+%}
+
+%include <std_shared_ptr.i>
+%include <std_string.i>
+%include <cartoswig.i>
+
+%import "datasources/TileDataSource.i"
+
+!polymorphic_shared_ptr(carto::OrderedTileDataSource, datasources.OrderedTileDataSource)
+
+%std_exceptions(carto::OrderedTileDataSource::OrderedTileDataSource)
+
+%feature("director") carto::OrderedTileDataSource;
+
+%include "datasources/OrderedTileDataSource.h"
+
+#endif

--- a/all/native/datasources/OrderedTileDataSource.cpp
+++ b/all/native/datasources/OrderedTileDataSource.cpp
@@ -1,0 +1,73 @@
+#include "OrderedTileDataSource.h"
+#include "core/MapTile.h"
+#include "components/Exceptions.h"
+#include "utils/Log.h"
+
+#include <memory>
+
+namespace carto {
+    
+    OrderedTileDataSource::OrderedTileDataSource(const std::shared_ptr<TileDataSource>& dataSource1, const std::shared_ptr<TileDataSource>& dataSource2) :
+        TileDataSource(),
+        _dataSource1(dataSource1),
+        _dataSource2(dataSource2)
+    {
+        if (!dataSource1) {
+            throw NullArgumentException("Null dataSource1");
+        }
+        if (!dataSource2) {
+            throw NullArgumentException("Null dataSource2");
+        }
+
+        _dataSourceListener = std::make_shared<DataSourceListener>(*this);
+        _dataSource1->registerOnChangeListener(_dataSourceListener);
+        _dataSource2->registerOnChangeListener(_dataSourceListener);
+    }
+    
+    OrderedTileDataSource::~OrderedTileDataSource() {
+        _dataSource2->unregisterOnChangeListener(_dataSourceListener);
+        _dataSource1->unregisterOnChangeListener(_dataSourceListener);
+        _dataSourceListener.reset();
+    }
+
+   int OrderedTileDataSource::getMinZoom() const {
+        return std::min(_dataSource1->getMinZoom(), _dataSource2->getMinZoom());
+    }
+
+    int OrderedTileDataSource::getMaxZoom() const {
+        return std::max(_dataSource1->getMinZoom(), _dataSource2->getMinZoom());
+    }
+
+    MapBounds OrderedTileDataSource::getDataExtent() const {
+        MapBounds bounds = _dataSource1->getDataExtent();
+        bounds.expandToContain(_dataSource2->getDataExtent());
+        return bounds;
+    }
+    
+    std::shared_ptr<TileData> OrderedTileDataSource::loadTile(const MapTile& mapTile) {
+        int zoom = mapTile.getZoom();
+        if (zoom <= _dataSource1->getMaxZoom() && zoom >= _dataSource1->getMinZoom()) {
+            std::shared_ptr<TileData> result = _dataSource1->loadTile(mapTile);
+            if (result != NULL && !result->isReplaceWithParent()) {
+                return result;
+            }
+        }
+        if (zoom <= _dataSource2->getMaxZoom() && zoom >= _dataSource2->getMinZoom()) {
+            std::shared_ptr<TileData> result = _dataSource2->loadTile(mapTile);
+            if (result != NULL && !result->isReplaceWithParent()) {
+                return result;
+            }
+        }
+        return NULL;
+    }
+
+    OrderedTileDataSource::DataSourceListener::DataSourceListener(OrderedTileDataSource& combinedDataSource) :
+        _combinedDataSource(combinedDataSource)
+    {
+    }
+    
+    void OrderedTileDataSource::DataSourceListener::onTilesChanged(bool removeTiles) {
+        _combinedDataSource.notifyTilesChanged(removeTiles);
+    }
+    
+}

--- a/all/native/datasources/OrderedTileDataSource.h
+++ b/all/native/datasources/OrderedTileDataSource.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2016 CartoDB. All rights reserved.
+ * Copying and using this code is allowed only according
+ * to license terms, as given in https://cartodb.com/terms/
+ */
+
+#ifndef _CARTO_OrderedTileDataSource_H_
+#define _CARTO_OrderedTileDataSource_H_
+
+#include "datasources/TileDataSource.h"
+#include "components/DirectorPtr.h"
+
+namespace carto {
+    
+    /**
+     * A tile data source that combines two data sources (usually offline and online) and selects tiles
+     * based on zoom level. All requests below specified zoom level are directed to the first data source
+     * and all requests at or above specified zoom level are directed to the second data source.
+     */
+    class OrderedTileDataSource : public TileDataSource {
+    public:
+        /**
+         * Constructs a combined tile data source object.
+         * @param dataSource1 First data source that is used if requested tile is below given zoomLevel.
+         * @param dataSource2 Second data source that is used if requested tile is at or above given zoomLevel.
+         * @param zoomLevel Threshold zoom level value.
+         */
+        OrderedTileDataSource(const std::shared_ptr<TileDataSource>& dataSource1, const std::shared_ptr<TileDataSource>& dataSource2);
+        virtual ~OrderedTileDataSource();
+
+        virtual int getMinZoom() const;
+        virtual int getMaxZoom() const;
+
+        virtual MapBounds getDataExtent() const;
+        
+        virtual std::shared_ptr<TileData> loadTile(const MapTile& tile);
+        
+    protected:
+        class DataSourceListener : public TileDataSource::OnChangeListener {
+        public:
+            explicit DataSourceListener(OrderedTileDataSource& combinedDataSource);
+            
+            virtual void onTilesChanged(bool removeTiles);
+            
+        private:
+            OrderedTileDataSource& _combinedDataSource;
+        };
+        
+        const DirectorPtr<TileDataSource> _dataSource1;
+        const DirectorPtr<TileDataSource> _dataSource2;
+        int _zoomLevel;
+        
+    private:
+        std::shared_ptr<DataSourceListener> _dataSourceListener;
+    };
+    
+}
+
+#endif

--- a/doc/loading_data.md
+++ b/doc/loading_data.md
@@ -686,6 +686,10 @@ An in-memory cache DataSource. Although layers also cache tiles, the tiles are u
 
 A tile DataSource that combines two data sources (usually offline and online) and selects tiles based on the zoom level. All requests below a specified zoom level are directed to the first DataSource. All requests at, or above, a specified zoom level are directed to the second Datasource.
 
+-   **OrderedTileDataSource**
+
+A tile DataSource that combines two data sources (usually offline packages and online) and selects tiles based on the order. It will try to get tiles for the first datasource (offline packages), and will use second datasource if no tile is found.
+
 ## Other Built-in DataSources
 
 The following datasources are also built into the Mobile SDK packages.


### PR DESCRIPTION
This is an implementation of the java version that i used.
I can't really test it in the context i am using it (offline packages and online source) because i don't have access to carto in my dev env.

The idea is to use ```PackageManagerTileDataSource``` and ```CartoOnlineTileDataSource```:
- if ```PackageManagerTileDataSource``` available use it
- if not use online one

It makes it for a better user experience and works online/offline
I made it with only 2 datasources while i was using an array of sources in java. But i dont really see how to do it right in C (with the JNI bridge).

let me know what i can add to make it go through