### PR TITLE
Fixed native crash when loading 0 sized files

### DIFF
--- a/android/native/utils/BitmapUtils.cpp
+++ b/android/native/utils/BitmapUtils.cpp
@@ -30,6 +30,10 @@ namespace carto {
         fseek(fp.get(), 0, SEEK_END);
         long size = ftell(fp.get());
         fseek(fp.get(), 0, SEEK_SET);
+        if (size <= 0) {
+            Log::Errorf("BitmapUtils::LoadBitmapFromFile: Ignore load due to size %d: %s", size, filePath.c_str());
+            return std::shared_ptr<Bitmap>();
+        }
         std::vector<unsigned char> data(static_cast<size_t>(size));
         fread(data.data(), 1, size, fp.get());
         return Bitmap::CreateFromCompressed(data.data(), data.size());


### PR DESCRIPTION
Fixed native crash due to missing check for 0 size or possible crash due to error in ftell, i.e. ftell might return -1, so lead to incorrect allocation. This will eliminate file check in java code and make image loading less error prone.