### PR TITLE
Hillshade layer improvements

### DIFF
--- a/all/modules/layers/HillshadeRasterTileLayer.i
+++ b/all/modules/layers/HillshadeRasterTileLayer.i
@@ -3,7 +3,7 @@
 
 %module HillshadeRasterTileLayer
 
-!proxy_imports(carto::HillshadeRasterTileLayer, datasources.TileDataSource, graphics.Color, layers.RasterTileLayer)
+!proxy_imports(carto::HillshadeRasterTileLayer, core.MapPos, core.MapPosVector, core.IntVector, datasources.TileDataSource, rastertiles.ElevationDecoder, graphics.Color, layers.RasterTileLayer)
 
 %{
 #include "layers/HillshadeRasterTileLayer.h"
@@ -15,13 +15,17 @@
 %include <cartoswig.i>
 
 %import "datasources/TileDataSource.i"
+%import "rastertiles/ElevationDecoder.i"
 %import "graphics/Color.i"
 %import "layers/RasterTileLayer.i"
+%import "core/IntVector.i"
 
 !polymorphic_shared_ptr(carto::HillshadeRasterTileLayer, layers.HillshadeRasterTileLayer)
 
 %attribute(carto::HillshadeRasterTileLayer, float, Contrast, getContrast, setContrast)
 %attribute(carto::HillshadeRasterTileLayer, float, HeightScale, getHeightScale, setHeightScale)
+%attribute(carto::HillshadeRasterTileLayer, float, IlluminationDirection, getIlluminationDirection, setIlluminationDirection)
+%attribute(carto::HillshadeRasterTileLayer, bool, IlluminationMapRotationEnabled, getIlluminationMapRotationEnabled, setIlluminationMapRotationEnabled)
 %attributeval(carto::HillshadeRasterTileLayer, carto::Color, ShadowColor, getShadowColor, setShadowColor)
 %attributeval(carto::HillshadeRasterTileLayer, carto::Color, HighlightColor, getHighlightColor, setHighlightColor)
 %std_exceptions(carto::HillshadeRasterTileLayer::HillshadeRasterTileLayer)

--- a/all/modules/rastertiles/ElevationDecoder.i
+++ b/all/modules/rastertiles/ElevationDecoder.i
@@ -1,0 +1,29 @@
+#ifndef _ELEVATIONDECODER_I
+#define _ELEVATIONDECODER_I
+
+%module ElevationDecoder
+
+!proxy_imports(carto::ElevationDecoder, graphics.Color, core.MapPos, core.MapPosVector, core.IntVector, datasources.TileDataSource)
+
+%{
+#include "rastertiles/ElevationDecoder.h"
+#include <memory>
+%}
+
+%include <std_shared_ptr.i>
+%include <cartoswig.i>
+
+%import "graphics/Color.i"
+%import "core/MapPos.i"
+%import "datasources/TileDataSource.i"
+%import "core/IntVector.i"
+
+!polymorphic_shared_ptr(carto::ElevationDecoder, rastertiles.ElevationDecoder)
+
+!standard_equals(carto::ElevationDecoder);
+%ignore carto::ElevationDecoder::getColorComponentCoefficients;
+%ignore carto::ElevationDecoder::getVectorTileScales;
+
+%include "rastertiles/ElevationDecoder.h"
+
+#endif

--- a/all/modules/rastertiles/MapBoxElevationDataDecoder.i
+++ b/all/modules/rastertiles/MapBoxElevationDataDecoder.i
@@ -1,0 +1,30 @@
+#ifndef _MAPBOXELEVATIONDATADECODER_I
+#define _MAPBOXELEVATIONDATADECODER_I
+
+%module MapBoxElevationDataDecoder
+
+%module(directors="1") MapBoxElevationDataDecoder
+!proxy_imports(carto::MapBoxElevationDataDecoder, graphics.Color, core.MapPos, core.MapPosVector, datasources.TileDataSource, rastertiles.ElevationDecoder)
+
+%{
+#include "rastertiles/MapBoxElevationDataDecoder.h"
+#include <memory>
+%}
+
+%include <std_shared_ptr.i>
+%include <cartoswig.i>
+
+%import "graphics/Color.i"
+%import "rastertiles/ElevationDecoder.i"
+
+!polymorphic_shared_ptr(carto::MapBoxElevationDataDecoder, rastertiles.MapBoxElevationDataDecoder)
+!standard_equals(carto::MapBoxElevationDataDecoder);
+
+%feature("director") carto::MapBoxElevationDataDecoder;
+
+%ignore carto::MapBoxElevationDataDecoder::getColorComponentCoefficients;
+%ignore carto::MapBoxElevationDataDecoder::getVectorTileScales;
+
+%include "rastertiles/MapBoxElevationDataDecoder.h"
+
+#endif

--- a/all/modules/rastertiles/TerrariumElevationDataDecoder.i
+++ b/all/modules/rastertiles/TerrariumElevationDataDecoder.i
@@ -1,0 +1,30 @@
+#ifndef _TERRARIUMELEVATIONDATADECODER_I
+#define _TERRARIUMELEVATIONDATADECODER_I
+
+%module TerrariumElevationDataDecoder
+
+%module(directors="1") TerrariumElevationDataDecoder
+!proxy_imports(carto::TerrariumElevationDataDecoder, graphics.Color, core.MapPos, core.MapPosVector, datasources.TileDataSource, rastertiles.ElevationDecoder)
+
+%{
+#include "rastertiles/TerrariumElevationDataDecoder.h"
+#include <memory>
+%}
+
+%include <std_shared_ptr.i>
+%include <cartoswig.i>
+
+%import "graphics/Color.i"
+%import "rastertiles/ElevationDecoder.i"
+
+!polymorphic_shared_ptr(carto::TerrariumElevationDataDecoder, rastertiles.TerrariumElevationDataDecoder)
+!standard_equals(carto::TerrariumElevationDataDecoder);
+
+%feature("director") carto::TerrariumElevationDataDecoder;
+
+%ignore carto::TerrariumElevationDataDecoder::getColorComponentCoefficients;
+%ignore carto::TerrariumElevationDataDecoder::getVectorTileScales;
+
+%include "rastertiles/TerrariumElevationDataDecoder.h"
+
+#endif

--- a/all/modules/routing/PackageManagerValhallaRoutingService.i
+++ b/all/modules/routing/PackageManagerValhallaRoutingService.i
@@ -5,7 +5,7 @@
 
 #if defined(_CARTO_ROUTING_SUPPORT) && defined(_CARTO_VALHALLA_ROUTING_SUPPORT) && defined(_CARTO_PACKAGEMANAGER_SUPPORT)
 
-!proxy_imports(carto::PackageManagerValhallaRoutingService, packagemanager.PackageManager, core.Variant, routing.RoutingService, routing.RoutingRequest, routing.RoutingResult, routing.RouteMatchingRequest, routing.RouteMatchingResult)
+!proxy_imports(carto::PackageManagerValhallaRoutingService, packagemanager.PackageManager, core.Variant, routing.RoutingService, routing.RoutingRequest, routing.RoutingResult, routing.RouteMatchingRequest, routing.RouteMatchingResult, datasources.TileDataSource, rastertiles.ElevationDecoder)
 
 %{
 #include "routing/PackageManagerValhallaRoutingService.h"
@@ -20,6 +20,8 @@
 %import "core/Variant.i"
 %import "routing/RoutingService.i"
 %import "packagemanager/PackageManager.i"
+%import "datasources/TileDataSource.i"
+%import "rastertiles/ElevationDecoder.i"
 
 !polymorphic_shared_ptr(carto::PackageManagerValhallaRoutingService, routing.PackageManagerValhallaRoutingService)
 

--- a/all/modules/routing/ValhallaOfflineRoutingService.i
+++ b/all/modules/routing/ValhallaOfflineRoutingService.i
@@ -5,7 +5,7 @@
 
 #if defined(_CARTO_ROUTING_SUPPORT) && defined(_CARTO_VALHALLA_ROUTING_SUPPORT) && defined(_CARTO_OFFLINE_SUPPORT)
 
-!proxy_imports(carto::ValhallaOfflineRoutingService, core.Variant, routing.RoutingService, routing.RoutingRequest, routing.RoutingResult, routing.RouteMatchingRequest, routing.RouteMatchingResult)
+!proxy_imports(carto::ValhallaOfflineRoutingService, core.Variant, routing.RoutingService, routing.RoutingRequest, routing.RoutingResult, routing.RouteMatchingRequest, routing.RouteMatchingResult, datasources.TileDataSource, rastertiles.ElevationDecoder)
 
 %{
 #include "routing/ValhallaOfflineRoutingService.h"
@@ -19,6 +19,8 @@
 
 %import "core/Variant.i"
 %import "routing/RoutingService.i"
+%import "datasources/TileDataSource.i"
+%import "rastertiles/ElevationDecoder.i"
 
 !polymorphic_shared_ptr(carto::ValhallaOfflineRoutingService, routing.ValhallaOfflineRoutingService)
 

--- a/all/native/layers/HillshadeRasterTileLayer.cpp
+++ b/all/native/layers/HillshadeRasterTileLayer.cpp
@@ -1,11 +1,15 @@
 #include "HillshadeRasterTileLayer.h"
-#include "graphics/Bitmap.h"
 #include "renderers/MapRenderer.h"
 #include "renderers/TileRenderer.h"
 #include "utils/Log.h"
+#include "core/BinaryData.h"
+#include "projections/EPSG3857.h"
+#include "projections/Projection.h"
 
 #include <array>
 #include <algorithm>
+
+#include "graphics/Bitmap.h"
 
 #include <vt/TileId.h>
 #include <vt/Tile.h>
@@ -14,27 +18,90 @@
 #include <vt/TileLayer.h>
 #include <vt/TileLayerBuilder.h>
 #include <vt/NormalMapBuilder.h>
+#include <vt/TileLayerBuilder.h>
 
-namespace carto {
+namespace {
 
-    HillshadeRasterTileLayer::HillshadeRasterTileLayer(const std::shared_ptr<TileDataSource>& dataSource) :
-        RasterTileLayer(dataSource),
+
+
+    std::array<std::uint8_t, 4> readTileBitmapColor(const std::shared_ptr<carto::Bitmap>& bitmap, int x, int y) {
+        x = std::max(0, std::min(x, (int)bitmap->getWidth() - 1));
+        y = bitmap->getHeight() - 1 - std::max(0, std::min(y, (int)bitmap->getHeight() - 1));
+
+        switch (bitmap->getColorFormat()) {
+            case carto::ColorFormat::COLOR_FORMAT_GRAYSCALE:
+            {
+                std::uint8_t val = bitmap->getPixelData()[y * bitmap->getWidth() + x];
+                return std::array<std::uint8_t, 4> { { val, val, val, 255 } };
+            }
+        case carto::ColorFormat::COLOR_FORMAT_RGB:
+            {
+                const std::uint8_t* valPtr = &bitmap->getPixelData()[(y * bitmap->getWidth() + x) * 3];
+                return std::array<std::uint8_t, 4> { { valPtr[0], valPtr[1], valPtr[2], 255 } };
+            }
+        case  carto::ColorFormat::COLOR_FORMAT_RGBA:
+            {
+                const std::uint8_t* valPtr = &bitmap->getPixelData()[(y * bitmap->getWidth() + x) * 4];
+                return std::array<std::uint8_t, 4> { { valPtr[0], valPtr[1], valPtr[2], valPtr[3] } };
+            }
+        default:
+            break;
+        }
+        return std::array<std::uint8_t, 4> { { 0, 0, 0, 0 } };
+    }
+
+    std::array<std::uint8_t, 4> readTileBitmapColor(const std::shared_ptr<carto::Bitmap>& bitmap, float x, float y) {
+        std::array<float, 4> result { { 0, 0, 0, 0 } };
+        for (int dy = 0; dy < 2; dy++) {
+            for (int dx = 0; dx < 2; dx++) {
+                int x0 = static_cast<int>(std::floor(x));
+                int y0 = static_cast<int>(std::floor(y));
+
+                std::array<std::uint8_t, 4> color = readTileBitmapColor(bitmap, x0 + dx, y0 + dy);
+                for (int i = 0; i < 4; i++) {
+                    result[i] += color[i] * (dx == 0 ? x0 + 1.0f - x : x - x0) * (dy == 0 ? y0 + 1.0f - y : y - y0);
+                }
+            }
+        }
+        return std::array<std::uint8_t, 4> { { static_cast<std::uint8_t>(result[0]), static_cast<std::uint8_t>(result[1]), static_cast<std::uint8_t>(result[2]), static_cast<std::uint8_t>(result[3]) } };
+    }
+
+    int readPixelAltitude(const std::shared_ptr<carto::Bitmap>& tileBitmap, const carto::MapBounds& tileBounds, const carto::MapPos& pos, const std::array<float, 4>& components) {
+        int tileSize = tileBitmap->getWidth();
+        float pixelX = (pos.getX() - tileBounds.getMin().getX()) / (tileBounds.getMax().getX() - tileBounds.getMin().getX()) * tileSize;
+        float pixelY = tileSize - (pos.getY() - tileBounds.getMin().getY()) / (tileBounds.getMax().getY() - tileBounds.getMin().getY()) * tileSize;
+        std::array<std::uint8_t, 4> interpolatedComponents = readTileBitmapColor(tileBitmap, pixelX - 0.5f, pixelY - 0.5f);
+        int altitude = std::round(components[0] * (float)interpolatedComponents[0] + components[1] * (float)interpolatedComponents[1] + components[2] * (float)interpolatedComponents[2] + components[3] * (float)interpolatedComponents[3]/255.0f);
+        return altitude;
+    }
+}
+
+namespace carto
+{
+
+    HillshadeRasterTileLayer::HillshadeRasterTileLayer(const std::shared_ptr<TileDataSource> &dataSource, const std::shared_ptr<ElevationDecoder> &elevationDecoder) : RasterTileLayer(dataSource),
+        _elevationDecoder(elevationDecoder),
         _contrast(0.5f),
         _heightScale(1.0f),
         _shadowColor(0, 0, 0, 255),
-        _highlightColor(255, 255, 255, 255)
+        _highlightColor(255, 255, 255, 255),
+        _illuminationDirection(67),
+        _illuminationMapRotationEnabled(true)
     {
     }
-    
-    HillshadeRasterTileLayer::~HillshadeRasterTileLayer() {
+
+    HillshadeRasterTileLayer::~HillshadeRasterTileLayer()
+    {
     }
-    
-    float HillshadeRasterTileLayer::getContrast() const {
+
+    float HillshadeRasterTileLayer::getContrast() const
+    {
         std::lock_guard<std::recursive_mutex> lock(_mutex);
         return _contrast;
     }
 
-    void HillshadeRasterTileLayer::setContrast(float contrast) {
+    void HillshadeRasterTileLayer::setContrast(float contrast)
+    {
         {
             std::lock_guard<std::recursive_mutex> lock(_mutex);
             _contrast = std::min(1.0f, std::max(0.0f, contrast));
@@ -42,12 +109,14 @@ namespace carto {
         tilesChanged(false);
     }
 
-    float HillshadeRasterTileLayer::getHeightScale() const {
+    float HillshadeRasterTileLayer::getHeightScale() const
+    {
         std::lock_guard<std::recursive_mutex> lock(_mutex);
         return _heightScale;
     }
 
-    void HillshadeRasterTileLayer::setHeightScale(float heightScale) {
+    void HillshadeRasterTileLayer::setHeightScale(float heightScale)
+    {
         {
             std::lock_guard<std::recursive_mutex> lock(_mutex);
             _heightScale = heightScale;
@@ -55,12 +124,14 @@ namespace carto {
         tilesChanged(false);
     }
 
-    Color HillshadeRasterTileLayer::getShadowColor() const {
+    Color HillshadeRasterTileLayer::getShadowColor() const
+    {
         std::lock_guard<std::recursive_mutex> lock(_mutex);
         return _shadowColor;
     }
 
-    void HillshadeRasterTileLayer::setShadowColor(const Color& color) {
+    void HillshadeRasterTileLayer::setShadowColor(const Color &color)
+    {
         {
             std::lock_guard<std::recursive_mutex> lock(_mutex);
             _shadowColor = color;
@@ -68,12 +139,14 @@ namespace carto {
         redraw();
     }
 
-    Color HillshadeRasterTileLayer::getHighlightColor() const {
+    Color HillshadeRasterTileLayer::getHighlightColor() const
+    {
         std::lock_guard<std::recursive_mutex> lock(_mutex);
         return _highlightColor;
     }
 
-    void HillshadeRasterTileLayer::setHighlightColor(const Color& color) {
+    void HillshadeRasterTileLayer::setHighlightColor(const Color &color)
+    {
         {
             std::lock_guard<std::recursive_mutex> lock(_mutex);
             _highlightColor = color;
@@ -81,22 +154,55 @@ namespace carto {
         redraw();
     }
 
-    bool HillshadeRasterTileLayer::onDrawFrame(float deltaSeconds, BillboardSorter& billboardSorter, const ViewState& viewState) {
+    float HillshadeRasterTileLayer::getIlluminationDirection() const
+    {
+        std::lock_guard<std::recursive_mutex> lock(_mutex);
+        return _illuminationDirection;
+    }
+    void HillshadeRasterTileLayer::setIlluminationDirection(float direction)
+    {
+        {
+            std::lock_guard<std::recursive_mutex> lock(_mutex);
+            _illuminationDirection = direction;
+        }
+        redraw();
+    }
+    bool HillshadeRasterTileLayer::getIlluminationMapRotationEnabled() const
+    {
+        std::lock_guard<std::recursive_mutex> lock(_mutex);
+        return _illuminationMapRotationEnabled;
+    }
+    void HillshadeRasterTileLayer::setIlluminationMapRotationEnabled(bool enabled)
+    {
+        {
+            std::lock_guard<std::recursive_mutex> lock(_mutex);
+            _illuminationMapRotationEnabled = enabled;
+        }
+        redraw();
+    }
+
+    bool HillshadeRasterTileLayer::onDrawFrame(float deltaSeconds, BillboardSorter &billboardSorter, const ViewState &viewState)
+    {
         updateTileLoadListener();
 
-        if (auto mapRenderer = getMapRenderer()) {
+        if (auto mapRenderer = getMapRenderer())
+        {
             float opacity = getOpacity();
 
-            if (opacity < 1.0f) {
+            if (opacity < 1.0f)
+            {
                 mapRenderer->clearAndBindScreenFBO(Color(0, 0, 0, 0), false, false);
             }
 
             _tileRenderer->setRasterFilterMode(getRasterFilterMode());
             _tileRenderer->setNormalMapShadowColor(getShadowColor());
             _tileRenderer->setNormalMapHighlightColor(getHighlightColor());
+            _tileRenderer->setNormalIlluminationDirection(getIlluminationDirection());
+            _tileRenderer->setNormalIlluminationMapRotationEnabled(getIlluminationMapRotationEnabled());
             bool refresh = _tileRenderer->onDrawFrame(deltaSeconds, viewState);
 
-            if (opacity < 1.0f) {
+            if (opacity < 1.0f)
+            {
                 mapRenderer->blendAndUnbindScreenFBO(opacity);
             }
 
@@ -104,8 +210,9 @@ namespace carto {
         }
         return false;
     }
-    
-    std::shared_ptr<vt::Tile> HillshadeRasterTileLayer::createVectorTile(const MapTile& tile, const std::shared_ptr<Bitmap>& bitmap) const {
+
+    std::shared_ptr<vt::Tile> HillshadeRasterTileLayer::createVectorTile(const MapTile &tile, const std::shared_ptr<Bitmap> &bitmap) const
+    {
         std::uint8_t alpha = 0;
         std::array<float, 4> scales;
         {
@@ -113,21 +220,22 @@ namespace carto {
             alpha = static_cast<std::uint8_t>(_contrast * 255.0f);
             float exaggeration = tile.getZoom() < 2 ? 0.2f : tile.getZoom() < 5 ? 0.3f : 0.35f;
             float scale = 16 * _heightScale * static_cast<float>(bitmap->getHeight() * std::pow(2.0, tile.getZoom() * (1 - exaggeration)) / 40075016.6855785);
-            scales = std::array<float, 4> { 65536 * scale, 256 * scale, scale, 0.0f };
+            scales = _elevationDecoder->getVectorTileScales();
+            std::transform(scales.begin(), scales.end(), scales.begin(), [&scale](float &c) { return c * scale; });
         }
-        
+
         // Build normal map from height map
         vt::TileId vtTileId(tile.getZoom(), tile.getX(), tile.getY());
         std::shared_ptr<Bitmap> rgbaBitmap = bitmap->getRGBABitmap();
-        auto rgbaBitmapDataPtr = reinterpret_cast<const std::uint32_t*>(rgbaBitmap->getPixelData().data());
+        auto rgbaBitmapDataPtr = reinterpret_cast<const std::uint32_t *>(rgbaBitmap->getPixelData().data());
         std::vector<std::uint32_t> rgbaBitmapData(rgbaBitmapDataPtr, rgbaBitmapDataPtr + rgbaBitmap->getWidth() * rgbaBitmap->getHeight());
         auto vtBitmap = std::make_shared<vt::Bitmap>(rgbaBitmap->getWidth(), rgbaBitmap->getHeight(), std::move(rgbaBitmapData));
         vt::NormalMapBuilder normalMapBuilder(scales, alpha);
         std::shared_ptr<const vt::Bitmap> normalMap = normalMapBuilder.buildNormalMapFromHeightMap(vtTileId, vtBitmap);
-        auto normalMapDataPtr = reinterpret_cast<const std::uint8_t*>(normalMap->data.data());
+        auto normalMapDataPtr = reinterpret_cast<const std::uint8_t *>(normalMap->data.data());
         std::vector<std::uint8_t> normalMapData(normalMapDataPtr, normalMapDataPtr + normalMap->data.size() * sizeof(std::uint32_t));
         auto tileBitmap = std::make_shared<vt::TileBitmap>(vt::TileBitmap::Type::NORMALMAP, vt::TileBitmap::Format::RGBA, normalMap->width, normalMap->height, std::move(normalMapData));
-        
+
         // Build vector tile from created normal map
         float tileSize = 256.0f; // 'normalized' tile size in pixels. Not really important
         std::shared_ptr<vt::TileBackground> tileBackground = std::make_shared<vt::TileBackground>(vt::Color(), std::shared_ptr<vt::BitmapPattern>());
@@ -135,7 +243,33 @@ namespace carto {
         vt::TileLayerBuilder tileLayerBuilder(vtTileId, 0, vtTransformer, tileSize, 1.0f); // Note: the size/scale argument is ignored
         tileLayerBuilder.addBitmap(tileBitmap);
         std::shared_ptr<vt::TileLayer> tileLayer = tileLayerBuilder.buildTileLayer(boost::optional<vt::CompOp>(), vt::FloatFunction(1));
-        return std::make_shared<vt::Tile>(vtTileId, tileSize, tileBackground, std::vector<std::shared_ptr<vt::TileLayer> > { tileLayer });
+        return std::make_shared<vt::Tile>(vtTileId, tileSize, tileBackground, std::vector<std::shared_ptr<vt::TileLayer>>{tileLayer});
     }
 
-}
+
+    std::shared_ptr<Bitmap> HillshadeRasterTileLayer::getMapTileBitmap(const MapTile& mapTile) const {
+        std::shared_ptr<TileData> tileData = _dataSource->loadTile(mapTile);
+        if (!tileData) {
+            Log::Error("HillshadeRasterTileLayer::getMapTileBitmap: Null tile data");
+            return NULL;
+        }
+
+        std::shared_ptr<BinaryData> binaryData = tileData->getData();
+        if (!binaryData) {
+            Log::Error("HillshadeRasterTileLayer::getMapTileBitmap: Null tile binary data");
+            return NULL;
+        }
+        int size = binaryData->size();
+        std::shared_ptr<Bitmap> tileBitmap = Bitmap::CreateFromCompressed(binaryData);
+        return tileBitmap;
+    }
+
+    int HillshadeRasterTileLayer::getElevation(MapPos &pos) const
+    {
+        return _elevationDecoder->getElevation(getDataSource(), pos);
+  }
+    std::vector<int> HillshadeRasterTileLayer::getElevations(const std::vector<MapPos> poses) const
+    {
+        return _elevationDecoder->getElevations(getDataSource(), poses);
+    }
+} // namespace carto

--- a/all/native/layers/HillshadeRasterTileLayer.h
+++ b/all/native/layers/HillshadeRasterTileLayer.h
@@ -8,7 +8,9 @@
 #define _CARTO_HILLSHADERASTERTILELAYER_H_
 
 #include "graphics/Color.h"
+#include "components/DirectorPtr.h"
 #include "layers/RasterTileLayer.h"
+#include "rastertiles/ElevationDecoder.h"
 
 namespace carto {
     
@@ -23,7 +25,7 @@ namespace carto {
          * Constructs a HillshadeRasterTileLayer object from a data source.
          * @param dataSource The data source from which this layer loads data.
          */
-        explicit HillshadeRasterTileLayer(const std::shared_ptr<TileDataSource>& dataSource);
+        explicit HillshadeRasterTileLayer(const std::shared_ptr<TileDataSource>& dataSource, const std::shared_ptr<ElevationDecoder>& elevationDecoder);
         virtual ~HillshadeRasterTileLayer();
 
         /**
@@ -69,16 +71,45 @@ namespace carto {
          * @param color The new highlight color of the layer.
          */
         void setHighlightColor(const Color& color);
+        /**
+         * Returns the illumination direction of the layer.
+         * @return direction in degrees.
+         */
+        float getIlluminationDirection() const;
+        /**
+         * Sets the illumination direction.
+         * @param direction in degrees.
+         */
+        void setIlluminationDirection(float direction);
+        /**
+         * Returns wheter the illumination direction should change with the map rotation.
+         * @return enabled
+         */
+        bool getIlluminationMapRotationEnabled() const;
+        /**
+         * Sets wheter the illumination direction should change with the map rotation.
+         * @param enabled whether to enable or not.
+         */
+        void setIlluminationMapRotationEnabled(bool enabled);
+
+        int getElevation(MapPos& pos) const;
+        std::vector<int> getElevations(const std::vector<MapPos> poses) const;
 
     protected:
         virtual bool onDrawFrame(float deltaSeconds, BillboardSorter& billboardSorter, const ViewState& viewState);
 
         virtual std::shared_ptr<vt::Tile> createVectorTile(const MapTile& tile, const std::shared_ptr<Bitmap>& bitmap) const;
 
+        std::shared_ptr<Bitmap> getMapTileBitmap(const MapTile& mapTile) const;
+
+        const DirectorPtr<ElevationDecoder> _elevationDecoder;
+   
         float _contrast;
         float _heightScale;
         Color _shadowColor;
         Color _highlightColor;
+        float _illuminationDirection;
+        bool _illuminationMapRotationEnabled;
     };
     
 }

--- a/all/native/rastertiles/ElevationDecoder.cpp
+++ b/all/native/rastertiles/ElevationDecoder.cpp
@@ -1,0 +1,148 @@
+#include "ElevationDecoder.h"
+#include "datasources/TileDataSource.h"
+#include "utils/Log.h"
+#include "utils/TileUtils.h"
+#include "core/MapBounds.h"
+#include "core/MapTile.h"
+#include "graphics/Bitmap.h"
+#include "projections/EPSG3857.h"
+#include "projections/Projection.h"
+
+#include <algorithm>
+namespace {
+
+
+
+    std::array<std::uint8_t, 4> readTileBitmapColor(const std::shared_ptr<carto::Bitmap>& bitmap, int x, int y) {
+        x = std::max(0, std::min(x, (int)bitmap->getWidth() - 1));
+        y = bitmap->getHeight() - 1 - std::max(0, std::min(y, (int)bitmap->getHeight() - 1));
+
+        switch (bitmap->getColorFormat()) {
+            case carto::ColorFormat::COLOR_FORMAT_GRAYSCALE:
+            {
+                std::uint8_t val = bitmap->getPixelData()[y * bitmap->getWidth() + x];
+                return std::array<std::uint8_t, 4> { { val, val, val, 255 } };
+            }
+            case carto::ColorFormat::COLOR_FORMAT_RGB:
+            {
+                const std::uint8_t* valPtr = &bitmap->getPixelData()[(y * bitmap->getWidth() + x) * 3];
+                return std::array<std::uint8_t, 4> { { valPtr[0], valPtr[1], valPtr[2], 255 } };
+            }
+            case  carto::ColorFormat::COLOR_FORMAT_RGBA:
+            {
+                const std::uint8_t* valPtr = &bitmap->getPixelData()[(y * bitmap->getWidth() + x) * 4];
+                return std::array<std::uint8_t, 4> { { valPtr[0], valPtr[1], valPtr[2], valPtr[3] } };
+            }
+            default:
+                break;
+        }
+        return std::array<std::uint8_t, 4> { { 0, 0, 0, 0 } };
+    }
+
+    std::array<std::uint8_t, 4> readTileBitmapColor(const std::shared_ptr<carto::Bitmap>& bitmap, float x, float y) {
+        std::array<float, 4> result { { 0, 0, 0, 0 } };
+        for (int dy = 0; dy < 2; dy++) {
+            for (int dx = 0; dx < 2; dx++) {
+                int x0 = static_cast<int>(std::floor(x));
+                int y0 = static_cast<int>(std::floor(y));
+
+                std::array<std::uint8_t, 4> color = readTileBitmapColor(bitmap, x0 + dx, y0 + dy);
+                for (int i = 0; i < 4; i++) {
+                    result[i] += color[i] * (dx == 0 ? x0 + 1.0f - x : x - x0) * (dy == 0 ? y0 + 1.0f - y : y - y0);
+                }
+            }
+        }
+        return std::array<std::uint8_t, 4> { { static_cast<std::uint8_t>(result[0]), static_cast<std::uint8_t>(result[1]), static_cast<std::uint8_t>(result[2]), static_cast<std::uint8_t>(result[3]) } };
+    }
+
+    int readPixelAltitude(const std::shared_ptr<carto::Bitmap>& tileBitmap, const carto::MapBounds& tileBounds, const carto::MapPos& pos, const std::array<float, 4>& components) {
+        int tileSize = tileBitmap->getWidth();
+        float pixelX = (pos.getX() - tileBounds.getMin().getX()) / (tileBounds.getMax().getX() - tileBounds.getMin().getX()) * tileSize;
+        float pixelY = tileSize - (pos.getY() - tileBounds.getMin().getY()) / (tileBounds.getMax().getY() - tileBounds.getMin().getY()) * tileSize;
+        std::array<std::uint8_t, 4> interpolatedComponents = readTileBitmapColor(tileBitmap, (int)pixelX, (int)pixelY);
+        int altitude = std::round(components[0] * (float)interpolatedComponents[0] + components[1] * (float)interpolatedComponents[1] + components[2] * (float)interpolatedComponents[2] + components[3] * (float)interpolatedComponents[3]/255.0f);
+        return altitude;
+    }
+}
+namespace carto
+{
+    ElevationDecoder::~ElevationDecoder()
+    {
+    }
+
+    ElevationDecoder::ElevationDecoder()
+    {
+    }
+    float ElevationDecoder::decodeHeight(const Color &encodedHeight) const
+    {
+        // the 4th component is used to "translate" the result
+        const std::array<float, 4> components = getColorComponentCoefficients();
+        return components[0] * encodedHeight.getR() + components[1] * encodedHeight.getG() + components[2] * encodedHeight.getB() + components[3] * encodedHeight.getA();
+    }
+    std::shared_ptr<Bitmap> ElevationDecoder::getMapTileBitmap(std::shared_ptr<TileDataSource> dataSource, const MapTile& mapTile) const {
+        std::shared_ptr<TileData> tileData = dataSource->loadTile(mapTile);
+        if (!tileData) {
+            Log::Error("ElevationDecoder::getMapTileBitmap: Null tile data");
+            return NULL;
+        }
+
+        std::shared_ptr<BinaryData> binaryData = tileData->getData();
+        if (!binaryData) {
+            Log::Error("ElevationDecoder::getMapTileBitmap: Null tile binary data");
+            return NULL;
+        }
+        std::shared_ptr<Bitmap> tileBitmap = Bitmap::CreateFromCompressed(binaryData);
+        return tileBitmap;
+    }
+    int ElevationDecoder::getElevation(std::shared_ptr<TileDataSource> dataSource, const MapPos &pos) const
+    {
+        // we need to transform pos to dataSource projection
+        // TODO: how to check if pos is in Wgs84?
+        std::shared_ptr<Projection> projection = dataSource->getProjection();
+        MapPos dataSourcePos = projection->fromWgs84(pos);
+
+        // The tile is flipped so to get the bitmap we need to flip it
+        MapTile mapTile = TileUtils::CalculateMapTile(dataSourcePos, dataSource->getMaxZoom(), projection);
+        MapTile flippedMapTile = mapTile.getFlipped();
+
+        std::shared_ptr<Bitmap> tileBitmap = getMapTileBitmap(dataSource, flippedMapTile);
+        if (!tileBitmap) {
+            Log::Error("ElevationDecoder::getElevation: Null tile bitmap");
+            return -1000000;
+        }
+        std::array<float, 4> components = getColorComponentCoefficients();
+        return readPixelAltitude(tileBitmap, TileUtils::CalculateMapTileBounds(mapTile, projection), dataSourcePos, components);
+    }
+    std::vector<int> ElevationDecoder::getElevations(std::shared_ptr<TileDataSource> dataSource, const std::vector<MapPos> poses) const
+    {
+        std::map<long long, std::pair<MapBounds, std::shared_ptr<Bitmap>>> indexedTiles;
+        std::vector<int> results;
+        std::shared_ptr<Projection> projection = dataSource->getProjection();
+        std::array<float, 4> components = getColorComponentCoefficients();
+        for (auto it = poses.begin(); it != poses.end(); it++) {
+            // TODO: how to check if pos is in Wgs84?
+            MapPos dataSourcePos = projection->fromWgs84(*it);
+            // The tile is flipped so to get the bitmap we need to flip it
+            MapTile mapTile = TileUtils::CalculateMapTile(dataSourcePos, dataSource->getMaxZoom(), projection);
+            MapTile flippedMapTile = mapTile.getFlipped();
+            long long tileId = mapTile.getTileId();
+            std::map<long long, std::pair<MapBounds, std::shared_ptr<Bitmap>>>::iterator iter(indexedTiles.lower_bound(tileId));
+            Log::Debugf("ElevationDecoder::getElevations: %d, %d, %d, %d",it->getY(),it->getY(), tileId, iter == indexedTiles.end());
+            if (iter == indexedTiles.end()) {
+                std::shared_ptr<Bitmap> tileBitmap = getMapTileBitmap(dataSource, flippedMapTile);
+                MapBounds tileBounds = TileUtils::CalculateMapTileBounds(mapTile, projection);
+                std::pair<MapBounds, std::shared_ptr<Bitmap>> pair = std::make_pair(tileBounds, tileBitmap);
+                indexedTiles.insert(std::pair<long long, std::pair<MapBounds, std::shared_ptr<Bitmap>>>(iter->first, pair));
+                int altitude = readPixelAltitude(tileBitmap, tileBounds, dataSourcePos, components);
+                results.push_back(altitude);
+            } else {
+                std::pair<MapBounds, std::shared_ptr<Bitmap>> pair = iter->second;
+                const std::shared_ptr<Bitmap>& tileBitmap = pair.second;
+                const MapBounds& tileBounds = pair.first;
+                int altitude = readPixelAltitude(tileBitmap, tileBounds, dataSourcePos, components);
+                results.push_back(altitude);
+            }
+        }
+        return results;
+    }
+} // namespace carto

--- a/all/native/rastertiles/ElevationDecoder.h
+++ b/all/native/rastertiles/ElevationDecoder.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2016 CartoDB. All rights reserved.
+ * Copying and using this code is allowed only according
+ * to license terms, as given in https://cartodb.com/terms/
+ */
+
+#ifndef _CARTO_ELEVATIONDECODER_H_
+#define _CARTO_ELEVATIONDECODER_H_
+
+#include "graphics/Color.h"
+#include "core/MapTile.h"
+#include "core/MapPos.h"
+
+#include <memory>
+#include <string>
+#include <mutex>
+#include <map>
+#include <vector>
+
+#include <cglib/mat.h>
+
+#include <mapnikvt/Map.h>
+
+namespace carto {
+    class Bitmap;
+    class TileDataSource;
+    /**
+     * Abstract base class for raster elevation decoders.
+     */
+    class ElevationDecoder {
+    public:
+    /**
+         * Constructs an ElevationDecoder.
+         */
+        ElevationDecoder();
+        virtual ~ElevationDecoder();
+        
+        virtual float decodeHeight(const Color& encodedHeight) const;
+        virtual std::array<float, 4> getVectorTileScales() const = 0;
+        virtual std::array<float, 4> getColorComponentCoefficients() const = 0;
+
+        int getElevation(std::shared_ptr<TileDataSource> dataSource, const MapPos &pos) const;
+        std::vector<int> getElevations(std::shared_ptr<TileDataSource> dataSource, const std::vector<MapPos> poses) const;
+
+    protected:
+        std::shared_ptr<Bitmap> getMapTileBitmap(std::shared_ptr<TileDataSource> dataSource, const MapTile& mapTile) const;
+
+    };
+        
+}
+
+#endif

--- a/all/native/rastertiles/MapBoxElevationDataDecoder.cpp
+++ b/all/native/rastertiles/MapBoxElevationDataDecoder.cpp
@@ -1,0 +1,27 @@
+#include "MapBoxElevationDataDecoder.h"
+
+namespace carto
+{
+
+    MapBoxElevationDataDecoder::MapBoxElevationDataDecoder() :
+        ElevationDecoder()
+    {
+    }
+
+    MapBoxElevationDataDecoder::~MapBoxElevationDataDecoder()
+    {
+    }
+
+    std::array<float, 4> MapBoxElevationDataDecoder::getColorComponentCoefficients() const
+    {
+        return COMPONENTS;
+    }
+
+    std::array<float, 4> MapBoxElevationDataDecoder::getVectorTileScales() const
+    {
+        return SCALES;
+    }
+
+    const std::array<float, 4> MapBoxElevationDataDecoder::COMPONENTS = std::array<float, 4>{256 * 256 * 0.1f, 256 * 0.1f, 0.1f, -10000.0f};
+    const std::array<float, 4> MapBoxElevationDataDecoder::SCALES = std::array<float, 4>{256 * 256, 256.0f, 1.0f, 0.0f};
+} // namespace carto

--- a/all/native/rastertiles/MapBoxElevationDataDecoder.h
+++ b/all/native/rastertiles/MapBoxElevationDataDecoder.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2016 CartoDB. All rights reserved.
+ * Copying and using this code is allowed only according
+ * to license terms, as given in https://cartodb.com/terms/
+ */
+
+#ifndef _CARTO_MAPBOXELEVATIONDATADECODER_H_
+#define _CARTO_MAPBOXELEVATIONDATADECODER_H_
+
+#include "rastertiles/ElevationDecoder.h"
+
+#include <memory>
+#include <mutex>
+#include <map>
+#include <string>
+
+namespace carto {
+
+    /**
+     * A decoder for MapBox encoded elevation tiles
+     */
+    class MapBoxElevationDataDecoder : public ElevationDecoder {
+    public:
+        /**
+         * Constructs a new MapBoxElevationDataDecoder.
+         */
+        MapBoxElevationDataDecoder();
+        virtual ~MapBoxElevationDataDecoder();
+
+        virtual std::array<float, 4> getVectorTileScales() const;
+        virtual std::array<float, 4> getColorComponentCoefficients() const;
+
+    private :
+        static const std::array<float, 4> COMPONENTS;
+        static const std::array<float, 4> SCALES;
+    };
+
+}
+
+#endif

--- a/all/native/rastertiles/TerrariumElevationDataDecoder.cpp
+++ b/all/native/rastertiles/TerrariumElevationDataDecoder.cpp
@@ -1,0 +1,27 @@
+#include "TerrariumElevationDataDecoder.h"
+
+namespace carto
+{
+
+    TerrariumElevationDataDecoder::TerrariumElevationDataDecoder() :
+        ElevationDecoder()
+    {
+    }
+
+    TerrariumElevationDataDecoder::~TerrariumElevationDataDecoder()
+    {
+    }
+
+    std::array<float, 4> TerrariumElevationDataDecoder::getColorComponentCoefficients() const
+    {
+        return COMPONENTS;
+    }
+
+    std::array<float, 4> TerrariumElevationDataDecoder::getVectorTileScales() const
+    {
+        return SCALES;
+    }
+
+    const std::array<float, 4> TerrariumElevationDataDecoder::COMPONENTS = std::array<float, 4>{256.0f, 1.0f, 1.0f / 256, -32768.0f};
+    const std::array<float, 4> TerrariumElevationDataDecoder::SCALES = std::array<float, 4>{256.0f, 1.0f, 1.0f / 256, -32768.0f};
+} // namespace carto

--- a/all/native/rastertiles/TerrariumElevationDataDecoder.h
+++ b/all/native/rastertiles/TerrariumElevationDataDecoder.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2016 CartoDB. All rights reserved.
+ * Copying and using this code is allowed only according
+ * to license terms, as given in https://cartodb.com/terms/
+ */
+
+#ifndef _CARTO_TERRARIUMELEVATIONDATADECODER_H_
+#define _CARTO_TERRARIUMELEVATIONDATADECODER_H_
+
+#include "rastertiles/ElevationDecoder.h"
+
+#include <memory>
+#include <mutex>
+#include <map>
+#include <string>
+
+namespace carto {
+
+    /**
+     * A decoder for Terrarium encoded elevation tiles
+     */
+    class TerrariumElevationDataDecoder : public ElevationDecoder {
+    public:
+        /**
+         * Constructs a new TerrariumElevationDataDecoder.
+         */
+        TerrariumElevationDataDecoder();
+        virtual ~TerrariumElevationDataDecoder();
+
+        virtual std::array<float, 4> getVectorTileScales() const;
+        virtual std::array<float, 4> getColorComponentCoefficients() const;
+
+    private :
+        static const std::array<float, 4> COMPONENTS;
+        static const std::array<float, 4> SCALES;
+    };
+
+}
+
+#endif

--- a/all/native/renderers/TileRenderer.h
+++ b/all/native/renderers/TileRenderer.h
@@ -53,6 +53,8 @@ namespace carto {
         void setRasterFilterMode(vt::RasterFilterMode filterMode);
         void setNormalMapShadowColor(const Color& color);
         void setNormalMapHighlightColor(const Color& color);
+        void setNormalIlluminationMapRotationEnabled(bool enabled);
+        void setNormalIlluminationDirection(float direction);
 
         void offsetLayerHorizontally(double offset);
     
@@ -89,6 +91,10 @@ namespace carto {
         double _horizontalLayerOffset;
         cglib::vec3<float> _viewDir;
         cglib::vec3<float> _mainLightDir;
+        double _normalIlluminationDirection;
+        bool _normalIlluminationMapRotationEnabled;
+        double _mapRotation;
+
         std::map<vt::TileId, std::shared_ptr<const vt::Tile> > _tiles;
         
         mutable std::mutex _mutex;

--- a/all/native/routing/PackageManagerValhallaRoutingService.cpp
+++ b/all/native/routing/PackageManagerValhallaRoutingService.cpp
@@ -6,6 +6,8 @@
 #include "packagemanager/handlers/ValhallaRoutingPackageHandler.h"
 #include "projections/Projection.h"
 #include "routing/ValhallaRoutingProxy.h"
+#include "datasources/TileDataSource.h"
+#include "rastertiles/ElevationDecoder.h"
 #include "utils/Const.h"
 #include "utils/Log.h"
 
@@ -19,7 +21,9 @@ namespace carto {
         _profile("pedestrian"),
         _configuration(ValhallaRoutingProxy::GetDefaultConfiguration()),
         _cachedPackageDatabases(),
-        _mutex()
+        _mutex(),
+        _elevationDataSource(),
+        _elevationDecoder()
     {
         if (!packageManager) {
             throw NullArgumentException("Null packageManager");
@@ -128,7 +132,7 @@ namespace carto {
                 _cachedPackageDatabases = packageDatabases;
             }
 
-            result = ValhallaRoutingProxy::CalculateRoute(_cachedPackageDatabases, _profile, _configuration, request);
+            result = ValhallaRoutingProxy::CalculateRoute(_cachedPackageDatabases, _profile, _configuration, request, _elevationDataSource, _elevationDecoder);
         });
 
         return result;
@@ -148,6 +152,10 @@ namespace carto {
         // Impossible
     }
 
+    void PackageManagerValhallaRoutingService::connectElevationDataSource(const std::shared_ptr<TileDataSource>& dataSource, const std::shared_ptr<ElevationDecoder>& elevationDecoder) {
+        _elevationDataSource = dataSource;
+        _elevationDecoder = elevationDecoder;
+    }
 }
 
 #endif

--- a/all/native/routing/PackageManagerValhallaRoutingService.h
+++ b/all/native/routing/PackageManagerValhallaRoutingService.h
@@ -23,6 +23,8 @@ namespace sqlite3pp {
 }
 
 namespace carto {
+    class TileDataSource;
+    class ElevationDecoder;
 
     /**
      * A routing service that uses routing packages from package manager.
@@ -56,6 +58,8 @@ namespace carto {
 
         virtual std::shared_ptr<RoutingResult> calculateRoute(const std::shared_ptr<RoutingRequest>& request) const;
 
+        void connectElevationDataSource(const std::shared_ptr<TileDataSource>& dataSource, const std::shared_ptr<ElevationDecoder>& elevationDecoder);
+
     protected:
         class PackageManagerListener : public PackageManager::OnChangeListener {
         public:
@@ -78,6 +82,8 @@ namespace carto {
 
     private:
         std::shared_ptr<PackageManagerListener> _packageManagerListener;
+        std::shared_ptr<TileDataSource> _elevationDataSource;
+        std::shared_ptr<ElevationDecoder> _elevationDecoder;
     };
     
 }

--- a/all/native/routing/ValhallaOfflineRoutingService.cpp
+++ b/all/native/routing/ValhallaOfflineRoutingService.cpp
@@ -3,6 +3,8 @@
 #include "ValhallaOfflineRoutingService.h"
 #include "components/Exceptions.h"
 #include "routing/ValhallaRoutingProxy.h"
+#include "datasources/TileDataSource.h"
+#include "rastertiles/ElevationDecoder.h"
 #include "utils/Const.h"
 #include "utils/Log.h"
 
@@ -16,7 +18,9 @@ namespace carto {
         _database(),
         _profile("pedestrian"),
         _configuration(ValhallaRoutingProxy::GetDefaultConfiguration()),
-        _mutex()
+        _mutex(),
+        _elevationDataSource(),
+        _elevationDecoder()
     {
         _database.reset(new sqlite3pp::database());
         if (_database->connect_v2(path.c_str(), SQLITE_OPEN_READONLY) != SQLITE_OK) {
@@ -82,9 +86,13 @@ namespace carto {
         }
 
         std::lock_guard<std::mutex> lock(_mutex);
-        return ValhallaRoutingProxy::CalculateRoute(std::vector<std::shared_ptr<sqlite3pp::database> > { _database }, _profile, _configuration, request);
+        return ValhallaRoutingProxy::CalculateRoute(std::vector<std::shared_ptr<sqlite3pp::database> > { _database }, _profile, _configuration, request, _elevationDataSource, _elevationDecoder);
     }
 
+    void ValhallaOfflineRoutingService::connectElevationDataSource(const std::shared_ptr<TileDataSource>& dataSource, const std::shared_ptr<ElevationDecoder>& elevationDecoder) {
+        _elevationDataSource = dataSource;
+        _elevationDecoder = elevationDecoder;
+    }
 }
 
 #endif

--- a/all/native/routing/ValhallaOfflineRoutingService.h
+++ b/all/native/routing/ValhallaOfflineRoutingService.h
@@ -21,6 +21,8 @@ namespace sqlite3pp {
 }
 
 namespace carto {
+    class TileDataSource;
+    class ElevationDecoder;
 
     /**
      * An offline routing service that uses Valhalla routing tiles.
@@ -55,11 +57,15 @@ namespace carto {
 
         virtual std::shared_ptr<RoutingResult> calculateRoute(const std::shared_ptr<RoutingRequest>& request) const;
 
+        void connectElevationDataSource(const std::shared_ptr<TileDataSource>& dataSource, const std::shared_ptr<ElevationDecoder>& elevationDecoder);
+
     private:
         std::shared_ptr<sqlite3pp::database> _database;
         std::string _profile;
         Variant _configuration;
         mutable std::mutex _mutex;
+        std::shared_ptr<TileDataSource> _elevationDataSource;
+        std::shared_ptr<ElevationDecoder> _elevationDecoder;
     };
     
 }

--- a/all/native/routing/ValhallaRoutingProxy.h
+++ b/all/native/routing/ValhallaRoutingProxy.h
@@ -27,6 +27,8 @@ namespace carto {
     class RoutingResult;
     class RouteMatchingRequest;
     class RouteMatchingResult;
+    class TileDataSource;
+    class ElevationDecoder;
     
     class ValhallaRoutingProxy {
     public:
@@ -35,7 +37,8 @@ namespace carto {
 
 #ifdef _CARTO_VALHALLA_ROUTING_SUPPORT
         static std::shared_ptr<RouteMatchingResult> MatchRoute(const std::vector<std::shared_ptr<sqlite3pp::database> >& databases, const std::string& profile, const Variant& config, const std::shared_ptr<RouteMatchingRequest>& request);
-        static std::shared_ptr<RoutingResult> CalculateRoute(const std::vector<std::shared_ptr<sqlite3pp::database> >& databases, const std::string& profile, const Variant& config, const std::shared_ptr<RoutingRequest>& request);
+        static std::shared_ptr<RoutingResult> CalculateRoute(const std::vector<std::shared_ptr<sqlite3pp::database> >& databases, const std::string& profile, const Variant& config, const std::shared_ptr<RoutingRequest>& request, const std::shared_ptr<TileDataSource>& elevationDataSource,
+        const std::shared_ptr<ElevationDecoder>& elevationDecoder);
 #endif
 
         static Variant GetDefaultConfiguration();


### PR DESCRIPTION
I create this first as a draft because changes still need to happen.
Here what is in this PR:
* added options
    - `illuminationDirection`
    - `illuminationMapRotationEnabled`
* changed default hillshade parameters for a better default render
* added ElevationDecoder and more explicitly MapBox and Terrarium decoders
* decoders are used for hillshade rendering and elevation computation
* `getElevation` and `getElevations` from `HillshadeRasterTileLayer`, `MapBoxElevationDataDecoder` and `MapBoxElevationDataDecoder` (decoders require a datasource too in the arguments)
* added possibility to link those decoders with Valhalla proxy to query elevation.

Now here are some remarks 
* `getElevation` and `getElevations` right now transform poses from wgs84. How to handle that correctly? Does it mean a projection argument need to be added?
* valhalla wont actually use the decoders to compute route elevation costing. I thought it would but i discovered Valhalla tiles need to be computed with elevation (or more precisely grade) for it to work. What i did will only allow Valhalla to use our decoder for the "height" route. Which is in fact not a real need anymore as you can do the same directly from the layer or the decoder
* i am not sure about where mutex shoud be used or not. Especially in  `getElevation` and `getElevations`

PS: i did manage to get elevation costing to work with Carto/Valhalla. It is really easy and could be added if you want in your packages. It even have no consequences on the package size. Let me know if you need any help in implementing that.