### PR TITLE
Routing result simplification

### DIFF
--- a/all/native/routing/ValhallaRoutingProxy.cpp
+++ b/all/native/routing/ValhallaRoutingProxy.cpp
@@ -511,6 +511,10 @@ namespace carto {
                 std::vector<valhalla::midgard::PointLL> shape = valhalla::midgard::decode<std::vector<valhalla::midgard::PointLL> >(legInfo.get("shape").get<std::string>());
                 points.reserve(points.size() + shape.size());
                 epsg3857Points.reserve(epsg3857Points.size() + shape.size());
+                for (std::size_t i = 0; i <= shape.size(); i++) {
+                    const valhalla::midgard::PointLL& point = shape.at(i);
+                    points.push_back(proj->fromLatLong(point.second, point.first));
+                }
 
                 const picojson::array& maneuvers = legInfo.get("maneuvers").get<picojson::array>();
                 for (std::size_t i = 0; i < maneuvers.size(); i++) {
@@ -522,15 +526,16 @@ namespace carto {
                         action = RoutingAction::ROUTING_ACTION_REACH_VIA_LOCATION;
                     }
 
-                    std::size_t pointIndex = points.size();
+                    std::size_t pointIndexEpsg3857 = points.size();
+                    std::size_t pointIndex = maneuver.get("begin_shape_index").get<std::int64_t>();
                     for (std::size_t j = static_cast<std::size_t>(maneuver.get("begin_shape_index").get<std::int64_t>()); j <= static_cast<std::size_t>(maneuver.get("end_shape_index").get<std::int64_t>()); j++) {
                         const valhalla::midgard::PointLL& point = shape.at(j);
                         epsg3857Points.push_back(epsg3857.fromLatLong(point.second, point.first));
-                        points.push_back(proj->fromLatLong(point.second, point.first));
+                        // points.push_back(proj->fromLatLong(point.second, point.first));
                     }
 
-                    float turnAngle = CalculateTurnAngle(epsg3857Points, pointIndex);
-                    float azimuth = CalculateAzimuth(epsg3857Points, pointIndex);
+                    float turnAngle = CalculateTurnAngle(epsg3857Points, pointIndexEpsg3857);
+                    float azimuth = CalculateAzimuth(epsg3857Points, pointIndexEpsg3857);
 
                     std::string streetName;
                     if (maneuver.get("street_names").is<picojson::array>()) {

--- a/all/native/routing/ValhallaRoutingProxy.cpp
+++ b/all/native/routing/ValhallaRoutingProxy.cpp
@@ -511,7 +511,7 @@ namespace carto {
                 std::vector<valhalla::midgard::PointLL> shape = valhalla::midgard::decode<std::vector<valhalla::midgard::PointLL> >(legInfo.get("shape").get<std::string>());
                 points.reserve(points.size() + shape.size());
                 epsg3857Points.reserve(epsg3857Points.size() + shape.size());
-                for (std::size_t i = 0; i <= shape.size(); i++) {
+                for (std::size_t i = 0; i < shape.size(); i++) {
                     const valhalla::midgard::PointLL& point = shape.at(i);
                     points.push_back(proj->fromLatLong(point.second, point.first));
                 }
@@ -526,12 +526,11 @@ namespace carto {
                         action = RoutingAction::ROUTING_ACTION_REACH_VIA_LOCATION;
                     }
 
-                    std::size_t pointIndexEpsg3857 = points.size();
+                    std::size_t pointIndexEpsg3857 = epsg3857Points.size();
                     std::size_t pointIndex = maneuver.get("begin_shape_index").get<std::int64_t>();
                     for (std::size_t j = static_cast<std::size_t>(maneuver.get("begin_shape_index").get<std::int64_t>()); j <= static_cast<std::size_t>(maneuver.get("end_shape_index").get<std::int64_t>()); j++) {
                         const valhalla::midgard::PointLL& point = shape.at(j);
                         epsg3857Points.push_back(epsg3857.fromLatLong(point.second, point.first));
-                        // points.push_back(proj->fromLatLong(point.second, point.first));
                     }
 
                     float turnAngle = CalculateTurnAngle(epsg3857Points, pointIndexEpsg3857);


### PR DESCRIPTION
This PR changes the points for the RoutingResult.
Before we were creating the points based on the manoeuvres. However this was adding unwanted duplicate points(multiple manoeuvres at the same point?).
On an example route (computed with android dev [here](https://github.com/Akylas/mobile-sdk/blob/develop/scripts/android-dev/app/src/main/java/com/akylas/cartotest/ui/main/SecondFragment.java#L282)):
* points returned from valhalla : 246
* points in returned RoutingResult: 350

Now with that PR it returns the shape returned from valhalla. And the instruction indexes are still correct.