### PR TITLE
feat: added doubleClickMaxDuration option

### DIFF
--- a/all/modules/components/Options.i
+++ b/all/modules/components/Options.i
@@ -37,6 +37,7 @@
 %attribute(carto::Options, bool, ClickTypeDetection, isClickTypeDetection, setClickTypeDetection)
 %attribute(carto::Options, bool, DoubleClickDetection, isDoubleClickDetection, setDoubleClickDetection)
 %attribute(carto::Options, float, LongClickDuration, getLongClickDuration, setLongClickDuration)
+%attribute(carto::Options, float, DoubleClickMaxDuration, getDoubleClickMaxDuration, setDoubleClickMaxDuration)
 %attribute(carto::Options, bool, KineticPan, isKineticPan, setKineticPan)
 %attribute(carto::Options, bool, KineticRotation, isKineticRotation, setKineticRotation)
 %attribute(carto::Options, bool, SeamlessPanning, isSeamlessPanning, setSeamlessPanning)

--- a/all/native/components/Options.cpp
+++ b/all/native/components/Options.cpp
@@ -27,6 +27,7 @@ namespace carto {
         _clickTypeDetection(true),
         _doubleClickDetection(true),
         _longClickDuration(DEFAULT_LONG_CLICK_DURATION),
+        _doubleClickMaxDuration(DEFAULT_DOUBLE_CLICK_MAX_DURATION),
         _tileDrawSize(256),
         _dpi(160.0f),
         _drawDistance(16),
@@ -190,6 +191,22 @@ namespace carto {
             _longClickDuration = duration;
         }
         notifyOptionChanged("LongClickDuration");
+    }
+
+    float Options::getDoubleClickMaxDuration() const {
+        std::lock_guard<std::mutex> lock(_mutex);
+        return _doubleClickMaxDuration;
+    }
+
+    void Options::setDoubleClickMaxDuration(float duration) {
+        {
+            std::lock_guard<std::mutex> lock(_mutex);
+            if (_doubleClickMaxDuration == duration) {
+                return;
+            }
+            _doubleClickMaxDuration = duration;
+        }
+        notifyOptionChanged("DoubleClickMaxDuration");
     }
 
     int Options::getTileDrawSize() const {
@@ -808,6 +825,7 @@ namespace carto {
     }
 
     const float Options::DEFAULT_LONG_CLICK_DURATION = 0.4f;
+    const float Options::DEFAULT_DOUBLE_CLICK_MAX_DURATION = 0.4f;
     const Color Options::DEFAULT_CLEAR_COLOR = Color(0, 0, 0, 255);
     const Color Options::DEFAULT_SKY_COLOR = Color(149, 196, 255, 255);
     const Color Options::DEFAULT_BACKGROUND_COLOR = Color(226, 226, 226, 255);

--- a/all/native/components/Options.h
+++ b/all/native/components/Options.h
@@ -191,6 +191,17 @@ namespace carto {
          * @param duration The new duration for the long click in seconds.
          */
         void setLongClickDuration(float duration);
+
+        /**
+         * Returns the double click max duration in seconds.
+         * @return The double click maxin seconds.
+         */
+        float getDoubleClickMaxDuration() const;
+        /**
+         * Sets the double click max in seconds. The default is value is 0.4 (400ms).
+         * @param duration The new value for the double click max duration detection in seconds.
+         */
+        void setDoubleClickMaxDuration(float duration);
     
         /**
          * Returns the tile size used for drawing map tiles.
@@ -600,6 +611,7 @@ namespace carto {
 
     private:
         static const float DEFAULT_LONG_CLICK_DURATION;
+        static const float DEFAULT_DOUBLE_CLICK_MAX_DURATION;
         static const Color DEFAULT_CLEAR_COLOR;
         static const Color DEFAULT_SKY_COLOR;
         static const Color DEFAULT_BACKGROUND_COLOR;
@@ -618,6 +630,7 @@ namespace carto {
         bool _clickTypeDetection;
         bool _doubleClickDetection;
         float _longClickDuration;
+        float _doubleClickMaxDuration;
     
         int _tileDrawSize;
     

--- a/all/native/ui/workers/ClickHandlerWorker.cpp
+++ b/all/native/ui/workers/ClickHandlerWorker.cpp
@@ -237,6 +237,7 @@ namespace carto {
 
                     auto deltaTime = std::chrono::steady_clock::now() - _startTime;
                     auto longClickDuration = std::chrono::milliseconds(static_cast<int>(_options->getLongClickDuration() * 1000.0f));
+                    auto doubleClickMaxDuration = std::chrono::milliseconds(static_cast<int>(_options->getDoubleClickMaxDuration() * 1000.0f));
                     switch (_clickMode) {
                     case NO_CLICK:
                         _chosen = true;
@@ -247,7 +248,7 @@ namespace carto {
                         }
                         break;
                     case DOUBLE_CLICK:
-                        if (_clickTypeDetection && deltaTime >= DOUBLE_CLICK_MAX_DURATION) {
+                        if (_clickTypeDetection && deltaTime >= doubleClickMaxDuration) {
                             _chosen = true;
                             _canceled = true;
                         }
@@ -356,7 +357,6 @@ namespace carto {
         
     const std::chrono::milliseconds ClickHandlerWorker::DUAL_CLICK_BEGIN_DURATION = std::chrono::milliseconds(100);
     const std::chrono::milliseconds ClickHandlerWorker::DUAL_CLICK_END_DURATION = std::chrono::milliseconds(300);
-    const std::chrono::milliseconds ClickHandlerWorker::DOUBLE_CLICK_MAX_DURATION = std::chrono::milliseconds(400);
         
     const float ClickHandlerWorker::DOUBLE_CLICK_TOLERANCE_INCHES = 1.3f;
     const float ClickHandlerWorker::MOVING_TOLERANCE_INCHES = 0.2f;


### PR DESCRIPTION
This allows fine setting to fine tune the behavior of doubleclick/singleclick

BTW: android default duration for double click is 300ms we use 400ms we is quite bigger