### PR TITLE
feat: Multidatasource

### DIFF
--- a/all/modules/datasources/MultiTileDataSource.i
+++ b/all/modules/datasources/MultiTileDataSource.i
@@ -1,0 +1,39 @@
+#ifndef _LOCALPACKAGEMANAGERTILEDATASOURCE_I
+#define _LOCALPACKAGEMANAGERTILEDATASOURCE_I
+
+%module(directors="1") MultiTileDataSource
+
+!proxy_imports(carto::MultiTileDataSource, core.MapTile, core.MapBounds, core.StringMap, datasources.TileDataSource, datasources.MBTilesTileDataSource, datasources.components.TileData)
+
+%{
+#include "datasources/MultiTileDataSource.h"
+#include "components/Exceptions.h"
+#include <memory>
+%}
+
+%include <std_shared_ptr.i>
+%include <std_string.i>
+%include <cartoswig.i>
+
+%import "core/MapTile.i"
+%import "core/StringMap.i"
+%import "datasources/TileDataSource.i"
+%import "datasources/MBTilesTileDataSource.i"
+%import "datasources/components/TileData.i"
+
+!polymorphic_shared_ptr(carto::MultiTileDataSource, datasources.MultiTileDataSource)
+
+%std_exceptions(carto::MultiTileDataSource::MultiTileDataSource)
+%std_exceptions(carto::LocalVectorDataSource::add)
+// %std_exceptions(carto::LocalVectorDataSource::addAll)
+%std_exceptions(carto::LocalVectorDataSource::remove)
+// %std_exceptions(carto::LocalVectorDataSource::removeAll)
+
+%ignore carto::LocalVectorDataSource::addAll;
+%ignore carto::LocalVectorDataSource::removeAll;
+
+%feature("director") carto::MultiTileDataSource;
+
+%include "datasources/MultiTileDataSource.h"
+
+#endif

--- a/all/native/datasources/MBTilesTileDataSource.cpp
+++ b/all/native/datasources/MBTilesTileDataSource.cpp
@@ -286,8 +286,6 @@ namespace carto {
         return true;
     }
 
-<<<<<<< HEAD
-=======
     std::string MBTilesTileDataSource::getMetaData(const std::string &key) const {
         // As a first step, try to use metadata
         std::string result;
@@ -304,7 +302,6 @@ namespace carto {
         }
         return result;
     }
->>>>>>> 527b8b95 (fix: working MultiTileDataSource (renamed from LocalPackageManagerTileDataSource))
 }
 
 #endif

--- a/all/native/datasources/MBTilesTileDataSource.cpp
+++ b/all/native/datasources/MBTilesTileDataSource.cpp
@@ -286,6 +286,25 @@ namespace carto {
         return true;
     }
 
+<<<<<<< HEAD
+=======
+    std::string MBTilesTileDataSource::getMetaData(const std::string &key) const {
+        // As a first step, try to use metadata
+        std::string result;
+        try {
+            sqlite3pp::query query(*_database, "SELECT value FROM metadata WHERE name=:name");
+            query.bind(":name", key.c_str());
+           for (auto it = query.begin(); it != query.end(); it++) {
+               result = (*it).get<const char*>(0);
+           }
+            query.finish();
+        }
+        catch (const std::exception& ex) {
+            Log::Errorf("MBTilesTileDataSource::getMetaData: Exception while reading %s metadata: %s", key, ex.what());
+        }
+        return result;
+    }
+>>>>>>> 527b8b95 (fix: working MultiTileDataSource (renamed from LocalPackageManagerTileDataSource))
 }
 
 #endif

--- a/all/native/datasources/MBTilesTileDataSource.h
+++ b/all/native/datasources/MBTilesTileDataSource.h
@@ -81,6 +81,13 @@ namespace carto {
          * @return Map containing meta data information (parameter names mapped to parameter values).
          */
         std::map<std::string, std::string> getMetaData() const;
+
+        /**
+         * Query a metadata value
+         * Possible parameters can be found in MBTiles specification.
+         * @return a string representation of the metadata value
+         */
+        std::string MBTilesTileDataSource::getMetaData(const std::string &key) const;
         
         virtual int getMinZoom() const;
 

--- a/all/native/datasources/MultiTileDataSource.cpp
+++ b/all/native/datasources/MultiTileDataSource.cpp
@@ -1,0 +1,208 @@
+#include "MultiTileDataSource.h"
+#include "core/MapTile.h"
+#include "components/Exceptions.h"
+#include "utils/GeneralUtils.h"
+#include "utils/Log.h"
+#include "utils/Const.h"
+#include "packagemanager/PackageTileMask.h"
+#include "datasources/MBTilesTileDataSource.h"
+
+#include <boost/lexical_cast.hpp>
+
+#include <memory>
+
+namespace carto {
+
+    MultiTileDataSource::MultiTileDataSource(int maxOpenedPackages) : TileDataSource(0, Const::MAX_SUPPORTED_ZOOM_LEVEL),
+                                                                                                  _dataSources(),
+                                                                                                  _cachedOpenDataSources(),
+                                                                                                  _maxOpenedPackages(maxOpenedPackages),
+                                                                                                  _mutex()
+    {
+    }
+    MultiTileDataSource::MultiTileDataSource() : TileDataSource(0, Const::MAX_SUPPORTED_ZOOM_LEVEL),
+                                                                             _dataSources(),
+                                                                             _cachedOpenDataSources(),
+                                                                             _maxOpenedPackages(4),
+                                                                             _mutex()
+    {
+    }
+
+    MultiTileDataSource::~MultiTileDataSource() {
+    }
+
+    bool compare_datasource (std::pair<std::shared_ptr<PackageTileMask>, std::shared_ptr<TileDataSource>> dataSource1, std::pair<std::shared_ptr<PackageTileMask>, std::shared_ptr<TileDataSource>> dataSource2) {
+        return std::dynamic_pointer_cast<TileDataSource>(dataSource1.second) == std::dynamic_pointer_cast<TileDataSource>(dataSource2.second);
+    };
+
+    std::shared_ptr<TileData> MultiTileDataSource::loadTile(const MapTile &mapTile)
+    {
+        Log::Infof("MultiTileDataSource::loadTile: Loading %s", mapTile.toString().c_str());
+        try
+        {
+            MapTile mapTileFlipped = mapTile.getFlipped();
+
+            std::shared_ptr<TileData> tileData;
+            std::lock_guard<std::mutex> lock(_mutex);
+            bool tileOk = false;
+            const int zoom = mapTile.getZoom();
+            // Fast path: try already open packages
+            for (auto it = _cachedOpenDataSources.begin(); it != _cachedOpenDataSources.end(); it++)
+            {
+                auto dataSource = it->second;
+                if (zoom < dataSource->getMinZoom() || zoom > dataSource->getMaxZoom()) {
+                    continue;
+                }
+
+                std::shared_ptr<PackageTileMask> tileMask = it->first;
+                if (tileMask)
+                {
+                    if (tileMask->getTileStatus(mapTileFlipped) == PackageTileStatus::PACKAGE_TILE_STATUS_MISSING)
+                    {
+                        continue;
+                    }
+                }
+
+                tileData = dataSource->loadTile(mapTile);
+                tileOk = tileData && tileData->getData();
+                if (tileOk)
+                {
+                    std::rotate(_cachedOpenDataSources.begin(), it, it + 1);
+                    break;
+                }
+            }
+            if (!tileOk)
+            {
+                // Slow path: try other packages
+                for (auto it = _dataSources.begin(); it != _dataSources.end(); it++)
+                {
+
+                    if (auto dataSource = std::dynamic_pointer_cast<TileDataSource>(it->second))
+                    {
+                        auto it2 = std::find_if(_cachedOpenDataSources.begin(), _cachedOpenDataSources.end(), [&it](const std::pair<std::shared_ptr<PackageTileMask>, std::shared_ptr<TileDataSource>> pair)
+                        {  return pair.second == it->second; });
+                        if (it2 != _cachedOpenDataSources.end() && it2->second == it->second) {
+                            continue;
+                        }
+                        if (zoom < dataSource->getMinZoom() || zoom > dataSource->getMaxZoom()) {
+                            continue;
+                        }
+                        std::shared_ptr<PackageTileMask> tileMask = it->first;
+                        if (tileMask)
+                        {
+                            if (tileMask->getTileStatus(mapTileFlipped) == PackageTileStatus::PACKAGE_TILE_STATUS_MISSING)
+                            {
+                                continue;
+                            }
+                        }
+
+                        tileData = dataSource->loadTile(mapTile);
+                        tileOk = tileData && tileData->getData();
+                        if (tileOk) {
+                            _cachedOpenDataSources.insert(_cachedOpenDataSources.begin(), std::make_pair(tileMask, dataSource));
+                            if (_cachedOpenDataSources.size() > _maxOpenedPackages)
+                            {
+                                _cachedOpenDataSources.pop_back();
+                            }
+                            break;
+                        }
+                    }
+                }
+            }
+
+            if (!tileOk)
+            {
+
+                if (mapTile.getZoom() > getMinZoom())
+                {
+                    Log::Infof("MultiTileDataSource::loadTile: Tile data doesn't exist in the database, redirecting to parent");
+                    if (!tileData){
+                        tileData = std::make_shared<TileData>(std::shared_ptr<BinaryData>());
+                    }
+                    tileData->setReplaceWithParent(true);
+                }
+                else
+                {
+                    Log::Infof("MultiTileDataSource::loadTile: Tile data doesn't exist in the database");
+                    return std::shared_ptr<TileData>();
+                }
+            }
+            return tileData;
+        }
+        catch (const std::exception &ex)
+        {
+            Log::Errorf("PackageManagerTileDataSource::loadTile: Exception: %s", ex.what());
+        }
+        return std::shared_ptr<TileData>();
+    }
+
+    void MultiTileDataSource::onPackagesChanged(ChangeType changeType)
+    {
+        {
+            std::lock_guard<std::mutex> lock(_mutex);
+            _cachedOpenDataSources.clear();
+        }
+        notifyTilesChanged(changeType == PACKAGES_DELETED); // we need to remove tiles only if packages were deleted
+    }
+
+    void MultiTileDataSource::add(const std::shared_ptr<TileDataSource> &dataSource)
+    {
+        add(dataSource, std::string());
+    }
+
+    void MultiTileDataSource::add(const std::shared_ptr<TileDataSource> &dataSource, const std::string& tileMaskArg)
+    {
+        {
+            std::lock_guard<std::mutex> lock(_mutex);
+            auto it = std::find_if(_dataSources.begin(), _dataSources.end(), [&dataSource](const std::pair<std::shared_ptr<PackageTileMask>, std::shared_ptr<TileDataSource>> pair)
+            { return pair.second == dataSource; });
+            if (it != _dataSources.end()) {
+                return;
+            }
+            std::shared_ptr<PackageTileMask> tileMask;
+            std::string tileMaskStr = tileMaskArg;
+            if (tileMaskStr.empty()) {
+                if (auto mbtilesDatasource = std::dynamic_pointer_cast<MBTilesTileDataSource>(dataSource)) {
+                    tileMaskStr = mbtilesDatasource->getMetaData("tilemask");
+                }
+            }
+            if (!tileMaskStr.empty())
+            {
+                std::vector<std::string> parts = GeneralUtils::Split(tileMaskStr, ':');
+                if (!parts.empty())
+                {
+                    int zoomLevel;
+                    if (parts.size() > 1)
+                    {
+                        zoomLevel = boost::lexical_cast<int>(parts[1]);
+                    }
+                    else
+                    {
+                        zoomLevel = dataSource->getMaxZoom();
+                    }
+                    tileMask = std::make_shared<PackageTileMask>(parts[0], zoomLevel);
+                }
+            }
+            _dataSources.emplace_back(tileMask, dataSource);
+        }
+        onPackagesChanged(PACKAGES_ADDED);
+    }
+
+
+    bool MultiTileDataSource::remove(const std::shared_ptr<TileDataSource> &dataSource)
+    {
+        {
+            std::lock_guard<std::mutex> lock(_mutex);
+            auto it = std::remove_if(_dataSources.begin(), _dataSources.end(), [&dataSource](
+                    const std::pair<std::shared_ptr<PackageTileMask>, std::shared_ptr<TileDataSource>> pair) {
+                return pair.second == dataSource;
+            });
+            if (it == _dataSources.end()) {
+                return false;
+            }
+            _dataSources.erase(it);
+        }
+        onPackagesChanged(PACKAGES_DELETED);
+        return true;
+    }
+}

--- a/all/native/datasources/MultiTileDataSource.h
+++ b/all/native/datasources/MultiTileDataSource.h
@@ -31,6 +31,11 @@ namespace carto {
         MultiTileDataSource(int maxOpenedPackages);
         virtual ~MultiTileDataSource();
 
+        virtual int getMinZoom() const;
+        virtual int getMaxZoom() const;
+
+        virtual MapBounds getDataExtent() const;
+
         virtual std::shared_ptr<TileData> loadTile(const MapTile& mapTile);
 
         

--- a/all/native/datasources/MultiTileDataSource.h
+++ b/all/native/datasources/MultiTileDataSource.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2016 CartoDB. All rights reserved.
+ * Copying and using this code is allowed only according
+ * to license terms, as given in https://cartodb.com/terms/
+ */
+
+
+#ifndef _CARTO_LOCALPACKAGEMANAGERTILEDATASOURCE_H_
+#define _CARTO_LOCALPACKAGEMANAGERTILEDATASOURCE_H_
+
+#include "datasources/TileDataSource.h"
+#include "packagemanager/PackageTileMask.h"
+
+#include <memory>
+#include <mutex>
+#include <vector>
+#include <optional>
+
+namespace carto {
+
+    /**
+     * A tile data source that handles multiple data sources.
+     */
+    class MultiTileDataSource : public TileDataSource {
+    public:
+        /**
+         * Constructs a PackageManagerTileDataSource object.
+         * @param packageManager The package manager that is used to retrieve requested tiles.
+         */
+        explicit MultiTileDataSource();
+        MultiTileDataSource(int maxOpenedPackages);
+        virtual ~MultiTileDataSource();
+
+        virtual std::shared_ptr<TileData> loadTile(const MapTile& mapTile);
+
+        
+        /**
+         * Adds a new  data source to the  data source stack. The new  data source will be the last (and topmost)  data source.
+         * @param datasource The data source to be added.
+         */
+        void add(const std::shared_ptr<TileDataSource>& datasource);
+
+        /**
+         * Adds a new  data source to the  data source stack. The new  data source will be the last (and topmost)  data source.
+         * @param datasource The data source to be added.
+         */
+        void add(const std::shared_ptr<TileDataSource>& datasource, const std::string& tileMask);
+
+        /**
+         * Removes a data source from the sources stack.
+         * @param datasource The data source to be removed.
+         * @return True if the  data source was removed. False otherwise ( data source was not found).
+         */
+        bool remove(const std::shared_ptr<TileDataSource>& datasource);
+
+    protected:
+         enum ChangeType {
+            PACKAGES_ADDED,
+            PACKAGES_DELETED
+        };
+
+        mutable std::optional<int> _maxOpenedPackages;
+
+        mutable std::vector<std::pair<std::shared_ptr<PackageTileMask>, std::shared_ptr<TileDataSource> > > _dataSources;
+        mutable std::vector<std::pair<std::shared_ptr<PackageTileMask>, std::shared_ptr<TileDataSource> > > _cachedOpenDataSources;
+
+        mutable std::mutex _mutex;
+
+        void onPackagesChanged(ChangeType changeType);
+    };
+
+}
+
+#endif


### PR DESCRIPTION
This is a new datasource which kind of work like the PackageManagerDataSource but with any local datasource.
It allows to handle multiple datasources in a better way than order or combine.

A few notes:
* i am not really happy with [this](https://github.com/Akylas/mobile-sdk/blob/d243ebc7a2586506841ef7fcc014210c5f3cfb5e/all/native/datasources/MultiTileDataSource.cpp#L108=). The idea is not go through data sources which are already cached. I would prefer some kind of difference method between the 2 vectors but could not get it to work.
* i have one lasting issue with it for which i might need your help. The only issue i see is when used for hillshade like i do here https://github.com/Akylas/mobile-sdk/blob/master/scripts/android-dev/app/src/main/java/com/akylas/cartotest/ui/main/SecondFragment.java#L145= My issue is that for some reason the hillshade render is broken on "overzoom"

while debugging i can see that the over tiles are correctly loaded, if i break i even see that first the render is ok
<img width="1259" alt="Screenshot 2022-06-15 at 09 07 37" src="https://user-images.githubusercontent.com/655344/173780314-073acf8d-1a2c-478d-88c0-66a2d5a5ce02.png">
But then as it finishes rendering the map it then get broken
<img width="1298" alt="Screenshot 2022-06-15 at 09 07 46" src="https://user-images.githubusercontent.com/655344/173780417-8f0369c4-6d02-4a93-a4e5-5955e3f73cd1.png">

If i change the hillshade layer to not use the `MultiTileDataSource` but the `MBTilesTileDataSource` directly then it renders correctly(like the first screenshot).

hope you can help