### PR TITLE
[DatasSource] `maxOverzoomLevel`

### DIFF
--- a/all/modules/datasources/TileDataSource.i
+++ b/all/modules/datasources/TileDataSource.i
@@ -29,6 +29,7 @@
 
 %attribute(carto::TileDataSource, int, MinZoom, getMinZoom)
 %attribute(carto::TileDataSource, int, MaxZoom, getMaxZoom)
+%attribute(carto::TileDataSource, int, MaxOverzoomLevel, getMaxOverzoomLevel, setMaxOverzoomLevel)
 %attributeval(carto::TileDataSource, carto::MapBounds, DataExtent, getDataExtent)
 !attributestring_polymorphic(carto::TileDataSource, projections.Projection, Projection, getProjection)
 %ignore carto::TileDataSource::OnChangeListener;

--- a/all/native/datasources/MBTilesTileDataSource.h
+++ b/all/native/datasources/MBTilesTileDataSource.h
@@ -89,7 +89,7 @@ namespace carto {
         virtual MapBounds getDataExtent() const;
 
         virtual std::shared_ptr<TileData> loadTile(const MapTile& mapTile);
-    
+
     private:
         static std::unique_ptr<sqlite3pp::database> OpenDatabase(const std::string& path);
 

--- a/all/native/datasources/TileDataSource.h
+++ b/all/native/datasources/TileDataSource.h
@@ -53,6 +53,30 @@ namespace carto {
          */
         virtual int getMaxZoom() const;
 
+
+        /**
+         * Returns the maximum zoom level supported by this data source + getMaxOverzoomLevel if >= 0.
+         * @return The maximum zoom level supported (exclusive).
+         */
+        virtual int getMaxZoomWithOverzoom() const;
+
+        /**
+         * Sets the maximum overzoom level for this datasource.
+         * If a tile for the given zoom level Z is not available, SDK will try to use tiles with zoom levels Z-1, ..., Z-MaxOverzoomLevel.
+         * The default is -1 (disabled).
+         * @param overzoomLevel The new maximum overzoom value.
+         */
+        void setMaxOverzoomLevel(int overzoomLevel);
+
+        /**
+         * Gets the current maximum overzoom level for this datasource.
+         * Over it the datasource will not be "drawn"
+         * @return The current maximum overzoom level for this datasource.
+         */
+        int getMaxOverzoomLevel() const;
+
+        bool isMaxOverzoomLevelSet() const;
+
         /**
          * Returns the extent of the tiles in this data source.
          * The bounds are in coordinate system of the projection of the data source.
@@ -117,11 +141,12 @@ namespace carto {
 
         std::atomic<int> _minZoom;
         std::atomic<int> _maxZoom;
+        std::atomic<int> _maxOverzoomLevel;
         const std::shared_ptr<Projection> _projection;
     
     private:
         std::vector<std::shared_ptr<OnChangeListener> > _onChangeListeners;
-        mutable std::mutex _onChangeListenersMutex;
+        mutable std::mutex _mutex;
     };
     
 }

--- a/all/native/datasources/components/TileData.cpp
+++ b/all/native/datasources/components/TileData.cpp
@@ -4,7 +4,7 @@
 namespace carto {
     
     TileData::TileData(const std::shared_ptr<BinaryData>& data) :
-        _data(data), _expirationTime(), _replaceWithParent(false), _mutex()
+        _data(data), _expirationTime(), _replaceWithParent(false), _overzoom(false), _mutex()
     {
     }
 
@@ -40,6 +40,16 @@ namespace carto {
     void TileData::setReplaceWithParent(bool flag) {
         std::lock_guard<std::mutex> lock(_mutex);
         _replaceWithParent = flag;
+    }
+    
+    bool TileData::isOverZoom() const {
+        std::lock_guard<std::mutex> lock(_mutex);
+        return _overzoom;
+    }
+    
+    void TileData::setIsOverZoom(bool flag) {
+        std::lock_guard<std::mutex> lock(_mutex);
+        _overzoom = flag;
     }
     
     const std::shared_ptr<BinaryData>& TileData::getData() const {

--- a/all/native/datasources/components/TileData.h
+++ b/all/native/datasources/components/TileData.h
@@ -48,6 +48,17 @@ namespace carto {
          * @param flag True when the tile should be replaced with the parent, false otherwise.
          */
         void setReplaceWithParent(bool flag);
+
+        /**
+         * Returns true if the tile data source marked this as over zoom.
+         * @return True if the tile should not be drawn. False otherwise.
+         */
+        bool isOverZoom() const;
+        /**
+         * Set the parent overzoom flag.
+         * @return True if the tile should not be drawn. False otherwise.
+         */
+        void setIsOverZoom(bool flag);
         
         /**
          * Returns tile data as binary data.
@@ -59,6 +70,7 @@ namespace carto {
         const std::shared_ptr<BinaryData> _data;
         std::shared_ptr<std::chrono::steady_clock::time_point> _expirationTime;
         bool _replaceWithParent;
+        bool _overzoom;
         mutable std::mutex _mutex;
     };
 

--- a/all/native/layers/RasterTileLayer.cpp
+++ b/all/native/layers/RasterTileLayer.cpp
@@ -434,6 +434,11 @@ namespace carto {
             if (tileData->isReplaceWithParent()) {
                 continue;
             }
+            if(tileData->isOverZoom()) {
+                // we need to invalidate cache tiles to make sure we dont draw over
+                layer->_preloadingCache.remove(_tileId);
+                layer->_visibleCache.remove(_tileId);
+            }
 
             if (isCanceled()) {
                 break;

--- a/all/native/layers/VectorTileLayer.cpp
+++ b/all/native/layers/VectorTileLayer.cpp
@@ -608,6 +608,11 @@ namespace carto {
             if (tileData->isReplaceWithParent()) {
                 continue;
             }
+            if(tileData->isOverZoom()) {
+                // we need to invalidate cache tiles to make sure we dont draw over
+                layer->_preloadingCache.remove(_tileId);
+                layer->_visibleCache.remove(_tileId);
+            }
 
             if (isCanceled()) {
                 break;


### PR DESCRIPTION
AS we discussed here https://github.com/CartoDB/mobile-sdk/issues/503 i implemented it.
The best way (maybe the only way) was to implement it globally.
Though for now only `MBTilesDataSource` uses it. Not sure what other DataSource it makes sense for.