### PR TITLE
feat: allow calculateRoute and matchRoute to return rawResult

### DIFF
--- a/all/modules/routing/RouteMatchingResult.i
+++ b/all/modules/routing/RouteMatchingResult.i
@@ -29,6 +29,7 @@
 %attributeval(carto::RouteMatchingResult, std::vector<carto::MapPos>, Points, getPoints)
 %attributeval(carto::RouteMatchingResult, std::vector<carto::RouteMatchingEdge>, MatchingEdges, getMatchingEdges)
 %attributeval(carto::RouteMatchingResult, std::vector<carto::RouteMatchingPoint>, MatchingPoints, getMatchingPoints)
+%attributestring(carto::RouteMatchingResult, std::string, RawResult, getRawResult)
 %std_exceptions(carto::RouteMatchingResult::RouteMatchingResult)
 !standard_equals(carto::RouteMatchingResult);
 !custom_tostring(carto::RouteMatchingResult);

--- a/all/modules/routing/RoutingResult.i
+++ b/all/modules/routing/RoutingResult.i
@@ -29,6 +29,7 @@
 %attributeval(carto::RoutingResult, std::vector<carto::RoutingInstruction>, Instructions, getInstructions)
 %attribute(carto::RoutingResult, double, TotalDistance, getTotalDistance)
 %attribute(carto::RoutingResult, double, TotalTime, getTotalTime)
+%attributestring(carto::RoutingResult, std::string, RawResult, getRawResult)
 %std_exceptions(carto::RoutingResult::RoutingResult)
 !standard_equals(carto::RoutingResult);
 !custom_tostring(carto::RoutingResult);

--- a/all/native/routing/RouteMatchingResult.cpp
+++ b/all/native/routing/RouteMatchingResult.cpp
@@ -7,8 +7,9 @@
 
 namespace carto {
 
-    RouteMatchingResult::RouteMatchingResult(const std::shared_ptr<Projection>& projection, std::vector<RouteMatchingPoint> matchingPoints, std::vector<RouteMatchingEdge> matchingEdges) :
+    RouteMatchingResult::RouteMatchingResult(const std::shared_ptr<Projection>& projection, std::vector<RouteMatchingPoint> matchingPoints, std::vector<RouteMatchingEdge> matchingEdges, std::string rawResult) :
         _projection(projection),
+        _rawResult(rawResult),
         _matchingPoints(std::move(matchingPoints)),
         _matchingEdges(std::move(matchingEdges))
     {
@@ -39,6 +40,10 @@ namespace carto {
 
     const std::vector<RouteMatchingPoint>& RouteMatchingResult::getMatchingPoints() const {
         return _matchingPoints;
+    }
+
+    const std::string& RouteMatchingResult::getRawResult() const {
+        return _rawResult;
     }
 
     std::string RouteMatchingResult::toString() const {

--- a/all/native/routing/RouteMatchingResult.h
+++ b/all/native/routing/RouteMatchingResult.h
@@ -30,7 +30,7 @@ namespace carto {
          * @param matchingPoints The matched points corresponding to the requested points snapped to road network.
          * @param matchingEdges The matched edges that are referenced through matching points.
          */
-        RouteMatchingResult(const std::shared_ptr<Projection>& projection, std::vector<RouteMatchingPoint> matchingPoints, std::vector<RouteMatchingEdge> matchingEdges);
+        RouteMatchingResult(const std::shared_ptr<Projection>& projection, std::vector<RouteMatchingPoint> matchingPoints, std::vector<RouteMatchingEdge> matchingEdges, std::string rawResult);
         virtual ~RouteMatchingResult();
 
         /**
@@ -53,6 +53,10 @@ namespace carto {
          * @return The list with details of the matched points.
          */
         const std::vector<RouteMatchingPoint>& getMatchingPoints() const;
+        /**
+         * Returns raw result 
+         */
+        const std::string& getRawResult() const;
 
         /**
          * Creates a string representation of this result object, useful for logging.
@@ -64,6 +68,7 @@ namespace carto {
         std::shared_ptr<Projection> _projection;
         std::vector<RouteMatchingPoint> _matchingPoints;
         std::vector<RouteMatchingEdge> _matchingEdges;
+        std::string _rawResult;
     };
     
 }

--- a/all/native/routing/RoutingResult.cpp
+++ b/all/native/routing/RoutingResult.cpp
@@ -11,8 +11,9 @@
 
 namespace carto {
 
-    RoutingResult::RoutingResult(const std::shared_ptr<Projection>& projection, std::vector<MapPos> points, std::vector<RoutingInstruction> instructions) :
+    RoutingResult::RoutingResult(const std::shared_ptr<Projection>& projection, std::vector<MapPos> points, std::vector<RoutingInstruction> instructions, const std::string rawResult) :
         _projection(projection),
+        _rawResult(rawResult),
         _points(std::move(points)),
         _instructions(std::move(instructions))
     {
@@ -46,6 +47,10 @@ namespace carto {
         return std::accumulate(_instructions.begin(), _instructions.end(), 0.0, [](double time, const RoutingInstruction& instruction) {
             return time + instruction.getTime();
         });
+    }
+
+    const std::string& RoutingResult::getRawResult() const {
+        return _rawResult;
     }
 
     std::string RoutingResult::toString() const {

--- a/all/native/routing/RoutingResult.h
+++ b/all/native/routing/RoutingResult.h
@@ -29,7 +29,7 @@ namespace carto {
          * @param points The point list defining the routing path. Instructions refer to this list.
          * @param instructions The turn-by-turn instruction list.
          */
-        RoutingResult(const std::shared_ptr<Projection>& projection, std::vector<MapPos> points, std::vector<RoutingInstruction> instructions);
+        RoutingResult(const std::shared_ptr<Projection>& projection, std::vector<MapPos> points, std::vector<RoutingInstruction> instructions, const std::string rawResult);
         virtual ~RoutingResult();
 
         /**
@@ -58,6 +58,10 @@ namespace carto {
          * @return The total duration in seconds.
          */
         double getTotalTime() const;
+        /**
+         * Returns raw result 
+         */
+        const std::string& getRawResult() const;
 
         /**
          * Creates a string representation of this result object, useful for logging.
@@ -69,6 +73,7 @@ namespace carto {
         std::shared_ptr<Projection> _projection;
         std::vector<MapPos> _points;
         std::vector<RoutingInstruction> _instructions;
+        std::string _rawResult;
     };
     
 }

--- a/all/native/routing/SGREOfflineRoutingService.cpp
+++ b/all/native/routing/SGREOfflineRoutingService.cpp
@@ -139,7 +139,7 @@ namespace carto {
             results.push_back(std::move(result));
         }
 
-        RoutingResultBuilder resultBuilder(proj);
+        RoutingResultBuilder resultBuilder(proj, nullptr);
         for (std::size_t i = 0; i < results.size(); i++) {
             const sgre::Result& result = results[i];
             if (result.getInstructions().empty()) {

--- a/all/native/routing/utils/OSRMRoutingProxy.cpp
+++ b/all/native/routing/utils/OSRMRoutingProxy.cpp
@@ -43,7 +43,7 @@ namespace carto {
             results.push_back(std::move(result));
         }
 
-        RoutingResultBuilder resultBuilder(proj);
+        RoutingResultBuilder resultBuilder(proj, nullptr);
         for (std::size_t i = 0; i < results.size(); i++) {
             const osrm::Result& result = results[i];
             if (result.getInstructions().empty()) {
@@ -116,7 +116,7 @@ namespace carto {
             throw GenericException("Routing failed", responseDoc["status_message"].GetString());
         }
 
-        RoutingResultBuilder resultBuilder(proj);
+        RoutingResultBuilder resultBuilder(proj, json);
         
         std::vector<MapPos> wgs84Points = DecodeGeometry(responseDoc["route_geometry"].GetString());
         std::vector<MapPos> points;

--- a/all/native/routing/utils/RoutingResultBuilder.cpp
+++ b/all/native/routing/utils/RoutingResultBuilder.cpp
@@ -12,8 +12,9 @@
 
 namespace carto {
 
-    RoutingResultBuilder::RoutingResultBuilder(const std::shared_ptr<Projection>& proj) :
+    RoutingResultBuilder::RoutingResultBuilder(const std::shared_ptr<Projection>& proj, const std::string& rawResult) :
         _projection(proj),
+        _rawResult(rawResult),
         _points(),
         _instructions()
     {
@@ -57,7 +58,7 @@ namespace carto {
             }
             instructions.push_back(instrBuilder.buildRoutingInstruction());
         }
-        return std::make_shared<RoutingResult>(_projection, _points, std::move(instructions));
+        return std::make_shared<RoutingResult>(_projection, _points, std::move(instructions), _rawResult);
     }
 
     float RoutingResultBuilder::calculateTurnAngle(int pointIndex) const {

--- a/all/native/routing/utils/RoutingResultBuilder.h
+++ b/all/native/routing/utils/RoutingResultBuilder.h
@@ -23,7 +23,7 @@ namespace carto {
 
     class RoutingResultBuilder {
     public:
-        explicit RoutingResultBuilder(const std::shared_ptr<Projection>& proj);
+        explicit RoutingResultBuilder(const std::shared_ptr<Projection>& proj, const std::string& rawResult);
 
         int addPoints(const std::vector<MapPos>& points);
 
@@ -45,6 +45,7 @@ namespace carto {
         const std::shared_ptr<Projection> _projection;
         std::vector<MapPos> _points;
         std::list<RoutingInstructionBuilder> _instructions;
+        std::string _rawResult;
     };
     
 }


### PR DESCRIPTION
This PR makes 2 changes:
* add `rawResult` to `RoutingResult` and `RouteMatchingResult`. This allows to send any custom options to Valhalla and read the result as json string so that you can do anything with it without having to modify `RoutingResult` and `RouteMatchingResult`. It is also very useful for cross plaftorm frameworks like React Native or Nativescript. The reason is that to pass the result to JS you only need to marshall a string and not a full structure of std vector and tons of data.
* allow `RouteMatchingResult` to have to `matched_points`. Using custom parameters you can query only edge data. Without this PR it would throw because there is no `matched_points` (which you actually did not ask for).